### PR TITLE
Make SecurityDomainAdd export an Elytron realm that uses the legacy s…

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/Attribute.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/Attribute.java
@@ -38,6 +38,7 @@ public enum Attribute {
     AUTHENTICATION_MANAGER_CLASS_NAME("authentication-manager-class-name"),
     AUTHORIZATION_MANAGER_CLASS_NAME("authorization-manager-class-name"),
     CACHE_TYPE("cache-type"),
+    EXPORT_ELYTRON_REALM("export-elytron-realm"),
     CIPHER_SUITES("cipher-suites"),
     CLIENT_ALIAS("client-alias"),
     CLIENT_AUTH("client-auth"),

--- a/security/subsystem/src/main/java/org/jboss/as/security/Capabilities.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/Capabilities.java
@@ -1,0 +1,35 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2015, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.wildfly.security.auth.server.SecurityRealm;
+
+class Capabilities {
+
+    static final String SECURITY_REALM_CAPABILITY = "org.wildfly.security.security-realm";
+
+    static final RuntimeCapability<Void> SECURITY_REALM_RUNTIME_CAPABILITY = RuntimeCapability
+            .Builder.of(SECURITY_REALM_CAPABILITY, true, SecurityRealm.class)
+            .build();
+}

--- a/security/subsystem/src/main/java/org/jboss/as/security/Constants.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/Constants.java
@@ -117,4 +117,5 @@ public interface Constants {
     String LIST_CACHED_PRINCIPALS = "list-cached-principals";
     String FLUSH_CACHE = "flush-cache";
     String PRINCIPAL_ARGUMENT = "principal";
+    String EXPORT_ELYTRON_REALM = "export-elytron-realm";
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/JSSEResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/JSSEResourceDefinition.java
@@ -89,8 +89,9 @@ public class JSSEResourceDefinition extends SimpleResourceDefinition {
     }
 
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        SecurityDomainReloadWriteHandler writeHandler = new SecurityDomainReloadWriteHandler(ATTRIBUTES);
         for (AttributeDefinition attr : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(attr, null, new SecurityDomainReloadWriteHandler(attr));
+            resourceRegistration.registerReadWriteAttribute(attr, null, writeHandler);
         }
     }
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/LoginModuleResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/LoginModuleResourceDefinition.java
@@ -24,7 +24,6 @@
 
 package org.jboss.as.security;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
@@ -74,12 +73,14 @@ public class LoginModuleResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
+        SecurityDomainReloadWriteHandler writeHandler = new SecurityDomainReloadWriteHandler(ATTRIBUTES);
         for (AttributeDefinition attribute : ATTRIBUTES) {
-            resourceRegistration.registerReadWriteAttribute(attribute, null, new SecurityDomainReloadWriteHandler(attribute));
+            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
         }
     }
 
-    private static class LoginModuleAdd extends AbstractAddStepHandler {
+    private static class LoginModuleAdd extends SecurityDomainReloadAddHandler {
+
         @Override
         protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
             for (AttributeDefinition attribute : ATTRIBUTES) {

--- a/security/subsystem/src/main/java/org/jboss/as/security/Namespace.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/Namespace.java
@@ -36,12 +36,13 @@ public enum Namespace {
 
     SECURITY_1_0("urn:jboss:domain:security:1.0"),
     SECURITY_1_1("urn:jboss:domain:security:1.1"),
-    SECURITY_1_2("urn:jboss:domain:security:1.2");
+    SECURITY_1_2("urn:jboss:domain:security:1.2"),
+    SECURITY_2_0("urn:jboss:domain:security:2.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = SECURITY_1_2;
+    public static final Namespace CURRENT = SECURITY_2_0;
 
     private final String name;
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadAddHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadAddHandler.java
@@ -32,6 +32,7 @@ import org.jboss.msc.service.ServiceName;
  * @author Jason T. Greene
  */
 public abstract class SecurityDomainReloadAddHandler extends RestartParentResourceAddHandler {
+
     protected SecurityDomainReloadAddHandler() {
         super(Constants.SECURITY_DOMAIN);
     }
@@ -45,5 +46,13 @@ public abstract class SecurityDomainReloadAddHandler extends RestartParentResour
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
         return SecurityDomainResourceDefinition.getSecurityDomainServiceName(parentAddress);
+    }
+
+    @Override
+    protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
+        super.removeServices(context, parentService, parentModel);
+        // make sure the security realm service is also removed.
+        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(parentService.getSimpleName());
+        context.removeService(serviceName);
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadAddHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadAddHandler.java
@@ -32,7 +32,6 @@ import org.jboss.msc.service.ServiceName;
  * @author Jason T. Greene
  */
 public abstract class SecurityDomainReloadAddHandler extends RestartParentResourceAddHandler {
-
     protected SecurityDomainReloadAddHandler() {
         super(Constants.SECURITY_DOMAIN);
     }
@@ -52,7 +51,10 @@ public abstract class SecurityDomainReloadAddHandler extends RestartParentResour
     protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
         super.removeServices(context, parentService, parentModel);
         // make sure the security realm service is also removed.
-        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(parentService.getSimpleName());
-        context.removeService(serviceName);
+        ModelNode elytronRealm = SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM.resolveModelAttribute(context, parentModel);
+        if (elytronRealm.isDefined()) {
+            ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(elytronRealm.asString());
+            context.removeService(serviceName);
+        }
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadRemoveHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadRemoveHandler.java
@@ -52,7 +52,10 @@ public class SecurityDomainReloadRemoveHandler extends RestartParentResourceRemo
     protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
         super.removeServices(context, parentService, parentModel);
         // make sure the security realm service is also removed.
-        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(parentService.getSimpleName());
-        context.removeService(serviceName);
+        ModelNode elytronRealm = SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM.resolveModelAttribute(context, parentModel);
+        if (elytronRealm.isDefined()) {
+            ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(elytronRealm.asString());
+            context.removeService(serviceName);
+        }
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadRemoveHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadRemoveHandler.java
@@ -47,4 +47,12 @@ public class SecurityDomainReloadRemoveHandler extends RestartParentResourceRemo
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
         return SecurityDomainResourceDefinition.getSecurityDomainServiceName(parentAddress);
     }
+
+    @Override
+    protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
+        super.removeServices(context, parentService, parentModel);
+        // make sure the security realm service is also removed.
+        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(parentService.getSimpleName());
+        context.removeService(serviceName);
+    }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadWriteHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadWriteHandler.java
@@ -34,7 +34,7 @@ import org.jboss.msc.service.ServiceName;
  */
 public class SecurityDomainReloadWriteHandler extends RestartParentWriteAttributeHandler {
 
-    protected SecurityDomainReloadWriteHandler(final AttributeDefinition... definition) {
+    protected SecurityDomainReloadWriteHandler(final AttributeDefinition ... definition) {
         super(Constants.SECURITY_DOMAIN, definition);
     }
 
@@ -53,7 +53,10 @@ public class SecurityDomainReloadWriteHandler extends RestartParentWriteAttribut
     protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
         super.removeServices(context, parentService, parentModel);
         // make sure the security realm service is also removed.
-        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(parentService.getSimpleName());
-        context.removeService(serviceName);
+        ModelNode elytronRealm = SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM.resolveModelAttribute(context, parentModel);
+        if (elytronRealm.isDefined()) {
+            ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(elytronRealm.asString());
+            context.removeService(serviceName);
+        }
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadWriteHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadWriteHandler.java
@@ -34,7 +34,7 @@ import org.jboss.msc.service.ServiceName;
  */
 public class SecurityDomainReloadWriteHandler extends RestartParentWriteAttributeHandler {
 
-    protected SecurityDomainReloadWriteHandler(final AttributeDefinition ... definition) {
+    protected SecurityDomainReloadWriteHandler(final AttributeDefinition... definition) {
         super(Constants.SECURITY_DOMAIN, definition);
     }
 
@@ -47,5 +47,13 @@ public class SecurityDomainReloadWriteHandler extends RestartParentWriteAttribut
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
         return SecurityDomainResourceDefinition.getSecurityDomainServiceName(parentAddress);
+    }
+
+    @Override
+    protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
+        super.removeServices(context, parentService, parentModel);
+        // make sure the security realm service is also removed.
+        ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(parentService.getSimpleName());
+        context.removeService(serviceName);
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainRemove.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainRemove.java
@@ -1,0 +1,71 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2015, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ServiceRemoveStepHandler;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * <p>
+ * A handler that removes the security domain configuration. This implementation overrides some of the
+ * {@link org.jboss.as.controller.ServiceRemoveStepHandler} methods to ensure that the security realm capability is properly
+ * deregistered and that the security realm service is also removed. It differs from its superclass in that it uses the
+ * value defined in the {@code export-elytron-realm} attribute to dynamically build the capability and service names, whereas
+ * the superclass uses the security domain name.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+class SecurityDomainRemove extends ServiceRemoveStepHandler {
+
+    SecurityDomainRemove(final ServiceName serviceName, final AbstractAddStepHandler addHandler) {
+        super(serviceName, addHandler);
+    }
+
+    @Override
+    protected void recordCapabilitiesAndRequirements(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        // make sure the security realm capability is deregistered if needed.
+        ModelNode elytronRealm = SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM.resolveModelAttribute(context, resource.getModel());
+        if (elytronRealm.isDefined()) {
+            context.deregisterCapability(Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getDynamicName(elytronRealm.asString()));
+        }
+    }
+
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) {
+        super.performRuntime(context, operation, model);
+        if (context.isResourceServiceRestartAllowed()) {
+            ModelNode elytronRealm = model.get(Constants.EXPORT_ELYTRON_REALM);
+            if (elytronRealm.isDefined()) {
+                ServiceName serviceName = Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY.getCapabilityServiceName(elytronRealm.asString());
+                context.removeService(serviceName);
+            }
+        }
+    }
+}

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
@@ -34,7 +34,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ServiceRemoveStepHandler;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinition;
@@ -45,6 +45,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.security.logging.SecurityLogger;
@@ -67,12 +68,12 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .build();
 
-    public static final SimpleAttributeDefinition EXPORT_ELYTRON_REALM = new SimpleAttributeDefinitionBuilder(Constants.EXPORT_ELYTRON_REALM, ModelType.BOOLEAN, true)
-            .setAllowExpression(true)
-            .setDefaultValue(new ModelNode(false))
+    public static final SimpleAttributeDefinition EXPORT_ELYTRON_REALM = new SimpleAttributeDefinitionBuilder(Constants.EXPORT_ELYTRON_REALM, ModelType.STRING, true)
+            .setAllowExpression(false)
+            .setValidator(new StringLengthValidator(1, true))
             .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {CACHE_TYPE, EXPORT_ELYTRON_REALM};
+    public static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {CACHE_TYPE, EXPORT_ELYTRON_REALM};
 
     private final boolean registerRuntimeOnly;
     private final List<AccessConstraintDefinition> accessConstraints;
@@ -80,7 +81,7 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
     SecurityDomainResourceDefinition(boolean registerRuntimeOnly) {
         super(SecurityExtension.SECURITY_DOMAIN_PATH,
                 SecurityExtension.getResourceDescriptionResolver(Constants.SECURITY_DOMAIN), SecurityDomainAdd.INSTANCE,
-                new ServiceRemoveStepHandler(SecurityDomainService.SERVICE_NAME, SecurityDomainAdd.INSTANCE, Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY));
+                new SecurityDomainRemove(SecurityDomainService.SERVICE_NAME, SecurityDomainAdd.INSTANCE));
         this.registerRuntimeOnly = registerRuntimeOnly;
         ApplicationTypeConfig atc = new ApplicationTypeConfig(SecurityExtension.SUBSYSTEM_NAME, Constants.SECURITY_DOMAIN);
         AccessConstraintDefinition acd = new ApplicationTypeAccessConstraintDefinition(atc);
@@ -90,9 +91,8 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
-        SecurityDomainReloadWriteHandler handler = new SecurityDomainReloadWriteHandler(ATTRIBUTES);
-        for (AttributeDefinition attribute : ATTRIBUTES)
-            resourceRegistration.registerReadWriteAttribute(attribute, null, handler);
+        resourceRegistration.registerReadWriteAttribute(CACHE_TYPE, null, new SecurityDomainReloadWriteHandler());
+        resourceRegistration.registerReadWriteAttribute(EXPORT_ELYTRON_REALM, null, new ReloadRequiredWriteAttributeHandler());
     }
 
     @Override

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -66,23 +67,32 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .build();
 
+    public static final SimpleAttributeDefinition EXPORT_ELYTRON_REALM = new SimpleAttributeDefinitionBuilder(Constants.EXPORT_ELYTRON_REALM, ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {CACHE_TYPE, EXPORT_ELYTRON_REALM};
+
     private final boolean registerRuntimeOnly;
     private final List<AccessConstraintDefinition> accessConstraints;
 
     SecurityDomainResourceDefinition(boolean registerRuntimeOnly) {
         super(SecurityExtension.SECURITY_DOMAIN_PATH,
                 SecurityExtension.getResourceDescriptionResolver(Constants.SECURITY_DOMAIN), SecurityDomainAdd.INSTANCE,
-                new ServiceRemoveStepHandler(SecurityDomainService.SERVICE_NAME, SecurityDomainAdd.INSTANCE));
+                new ServiceRemoveStepHandler(SecurityDomainService.SERVICE_NAME, SecurityDomainAdd.INSTANCE, Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
         ApplicationTypeConfig atc = new ApplicationTypeConfig(SecurityExtension.SUBSYSTEM_NAME, Constants.SECURITY_DOMAIN);
         AccessConstraintDefinition acd = new ApplicationTypeAccessConstraintDefinition(atc);
-        this.accessConstraints = Arrays.asList((AccessConstraintDefinition) SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN, acd);
+        this.accessConstraints = Arrays.asList(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN, acd);
         setDeprecated(SecurityExtension.DEPRECATED_SINCE);
     }
 
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(CACHE_TYPE, null, new SecurityDomainReloadWriteHandler(CACHE_TYPE));
+        SecurityDomainReloadWriteHandler handler = new SecurityDomainReloadWriteHandler(ATTRIBUTES);
+        for (AttributeDefinition attribute : ATTRIBUTES)
+            resourceRegistration.registerReadWriteAttribute(attribute, null, handler);
     }
 
     @Override

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityExtension.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityExtension.java
@@ -60,7 +60,6 @@ import org.jboss.as.controller.transform.PathAddressTransformer;
 import org.jboss.as.controller.transform.ResourceTransformationContext;
 import org.jboss.as.controller.transform.ResourceTransformer;
 import org.jboss.as.controller.transform.TransformationContext;
-import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescription;
@@ -166,8 +165,7 @@ import org.jboss.msc.service.ServiceName;
         final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, SecuritySubsystemRootResourceDefinition.DEEP_COPY_SUBJECT_MODE);
         final ResourceTransformationDescriptionBuilder securityDomain = builder.addChildResource(SECURITY_DOMAIN_PATH);
-        securityDomain.getAttributeBuilder().setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, new ModelNode(false)),
-                            SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM)
+        securityDomain.getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, SecurityDomainResourceDefinition.CACHE_TYPE)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM)
                 .end();
@@ -233,8 +231,7 @@ import org.jboss.msc.service.ServiceName;
         ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
 
         ResourceTransformationDescriptionBuilder securityDomain = builder.addChildResource(SECURITY_DOMAIN_PATH);
-        securityDomain.getAttributeBuilder().setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, new ModelNode(false)),
-                SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM)
+        securityDomain.getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.DEFINED, SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM)
                 .end();
 
@@ -272,8 +269,7 @@ import org.jboss.msc.service.ServiceName;
         // fully compatible if this attribute is left undefined or if its set to false.
         ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         ResourceTransformationDescriptionBuilder securityDomain = builder.addChildResource(SECURITY_DOMAIN_PATH);
-        securityDomain.getAttributeBuilder().setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, new ModelNode(false)),
-                SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM)
+        securityDomain.getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.DEFINED, SecurityDomainResourceDefinition.EXPORT_ELYTRON_REALM)
                 .end();
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
@@ -849,5 +849,4 @@ public interface SecurityLogger extends BasicLogger {
      */
     @Message(id = NONE, value = "Action not specified")
     String actionNotSpecified();
-
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/realm/DomainContextRealm.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/realm/DomainContextRealm.java
@@ -45,25 +45,25 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  * <p>
  * A {@link org.wildfly.security.auth.server.SecurityRealm} implementation that delegates credential verification to the
  * underlying {@link org.jboss.as.security.plugins.SecurityDomainContext}. This realm is exported as a capability by the
- * security subsystem if the {@code export-elytron-realm} attribute is set to {@code true} in the security domain
- * configuration. The example bellow illustrates how to export a realm for the security domain {@code LegacyDomain}:
+ * security subsystem if the {@code export-elytron-realm} attribute is defined in the security domain configuration. The
+ * example bellow illustrates how to export a realm for the security domain {@code legacy-domain}:
  *
  * <pre>
- *     &lt;security-domain name="Legacy" cache-type="default" export-elytron-realm="true"&gt;
+ *     &lt;security-domain name="legacy-domain" cache-type="default" export-elytron-realm="legacy-realm"&gt;
  *         ...
  *     &lt;/security-domain&gt;
  * </pre>
  *</p>
  * <p>
- * The security domain name is used as the dynamic name of the exported realm. This is the name that must be used in the
- * {@code Elytron} subsystem to reference this {@link org.jboss.as.security.plugins.SecurityDomainContext} based realm.
- * So, for the above example, an {@code Elytron} configuration would look like this:
+ * The value of {@code export-elytron-realm} attribute is used as the dynamic name of the exported realm. This is the
+ * name that must be used in the {@code Elytron} subsystem to reference this {@link org.jboss.as.security.plugins.SecurityDomainContext}
+ * based realm. So, for the above example, an {@code Elytron} configuration would look like this:
  *
  * <pre>
  *     &lt;subsystem xmlns="urn:wildfly:elytron:1.0"&gt;
  *         &lt;security-domains&gt;
- *             &lt;security-domain name="ApplicationDomain" default-realm="Legacy"&gt;
- *                 &lt;realm name="Legacy"/&gt;
+ *             &lt;security-domain name="ApplicationDomain" default-realm="legacy-realm"&gt;
+ *                 &lt;realm name="legacy-realm"/&gt;
  *             &lt;/security-domain&gt;
  *         &lt;/security-domains&gt;
  *     &lt;/subsystem&gt;

--- a/security/subsystem/src/main/java/org/jboss/as/security/realm/DomainContextRealm.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/realm/DomainContextRealm.java
@@ -1,0 +1,170 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2015, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security.realm;
+
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import org.jboss.as.security.plugins.SecurityDomainContext;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.server.CredentialSupport;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.authz.Attributes;
+import org.wildfly.security.authz.AuthorizationIdentity;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+/**
+ * <p>
+ * A {@link org.wildfly.security.auth.server.SecurityRealm} implementation that delegates credential verification to the
+ * underlying {@link org.jboss.as.security.plugins.SecurityDomainContext}. This realm is exported as a capability by the
+ * security subsystem if the {@code export-elytron-realm} attribute is set to {@code true} in the security domain
+ * configuration. The example bellow illustrates how to export a realm for the security domain {@code LegacyDomain}:
+ *
+ * <pre>
+ *     &lt;security-domain name="Legacy" cache-type="default" export-elytron-realm="true"&gt;
+ *         ...
+ *     &lt;/security-domain&gt;
+ * </pre>
+ *</p>
+ * <p>
+ * The security domain name is used as the dynamic name of the exported realm. This is the name that must be used in the
+ * {@code Elytron} subsystem to reference this {@link org.jboss.as.security.plugins.SecurityDomainContext} based realm.
+ * So, for the above example, an {@code Elytron} configuration would look like this:
+ *
+ * <pre>
+ *     &lt;subsystem xmlns="urn:wildfly:elytron:1.0"&gt;
+ *         &lt;security-domains&gt;
+ *             &lt;security-domain name="ApplicationDomain" default-realm="Legacy"&gt;
+ *                 &lt;realm name="Legacy"/&gt;
+ *             &lt;/security-domain&gt;
+ *         &lt;/security-domains&gt;
+ *     &lt;/subsystem&gt;
+ * </pre>
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class DomainContextRealm implements SecurityRealm {
+
+    private SecurityDomainContext domainContext;
+
+    public DomainContextRealm(final SecurityDomainContext context) {
+        this.domainContext = context;
+    }
+
+    @Override
+    public RealmIdentity createRealmIdentity(final String name) throws RealmUnavailableException {
+        return new PicketBoxBasedIdentity(name);
+    }
+
+    @Override
+    public CredentialSupport getCredentialSupport(final Class<?> credentialType) throws RealmUnavailableException {
+        if (char[].class.isAssignableFrom(credentialType) || String.class.isAssignableFrom(credentialType) || ClearPassword.class.isAssignableFrom(credentialType)) {
+            return CredentialSupport.VERIFIABLE_ONLY;
+        }
+        return CredentialSupport.POSSIBLY_VERIFIABLE;
+    }
+
+    private class PicketBoxBasedIdentity implements RealmIdentity {
+
+        private final String identityName;
+
+        private Subject jaasSubject;
+
+        private PicketBoxBasedIdentity(final String identityName) {
+            this.identityName = identityName;
+        }
+
+        @Override
+        public String getName() {
+            return this.identityName;
+        }
+
+        @Override
+        public CredentialSupport getCredentialSupport(final Class<?> credentialType) throws RealmUnavailableException {
+            return DomainContextRealm.this.getCredentialSupport(credentialType);
+        }
+
+        @Override
+        public <C> C getCredential(final Class<C> credentialType) throws RealmUnavailableException {
+            return null;
+        }
+
+        @Override
+        public boolean verifyCredential(final Object credential) throws RealmUnavailableException {
+            if (domainContext == null || domainContext.getAuthenticationManager() == null) {
+                throw new RealmUnavailableException();
+            }
+            else {
+                jaasSubject = new Subject();
+                Object jaasCredential = credential;
+                if (credential instanceof ClearPassword) {
+                    jaasCredential = ((ClearPassword) credential).getPassword();
+                }
+                return domainContext.getAuthenticationManager().isValid(new NamePrincipal(identityName), jaasCredential, jaasSubject);
+            }
+        }
+
+        @Override
+        public boolean exists() throws RealmUnavailableException {
+            return true;
+        }
+
+        @Override
+        public AuthorizationIdentity getAuthorizationIdentity() throws RealmUnavailableException {
+            Attributes attributes = null;
+            if (this.jaasSubject != null) {
+                /* process the JAAS subject, extracting attributes from groups that might have been set in the subject
+                   by the JAAS login modules (e.g. caller principal, roles) */
+                final Set<Principal> principals = jaasSubject.getPrincipals();
+                if (principals != null) {
+                    for (Principal principal : principals) {
+                        if (principal instanceof Group) {
+                            final String key = principal.getName();
+                            final Set<String> values = new HashSet<>();
+                            final Enumeration<? extends Principal> enumeration = ((Group) principal).members();
+                            while (enumeration.hasMoreElements()) {
+                                values.add(enumeration.nextElement().getName());
+                            }
+                            if (attributes == null) {
+                                attributes = new MapAttributes();
+                            }
+                            attributes.addAll(key, values);
+                        }
+                    }
+                }
+            }
+            if (attributes == null)
+                attributes = Attributes.EMPTY;
+            return AuthorizationIdentity.basicIdentity(attributes);
+        }
+    }
+}

--- a/security/subsystem/src/main/java/org/jboss/as/security/realm/DomainContextRealmService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/realm/DomainContextRealmService.java
@@ -1,0 +1,64 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2015, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security.realm;
+
+import org.jboss.as.security.plugins.SecurityDomainContext;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.security.auth.server.SecurityRealm;
+
+/**
+ * A {@link org.jboss.msc.service.Service} that instantiates a {@link org.jboss.as.security.realm.DomainContextRealm}.
+ *
+ * @author <a href="sguilhen@jboss.com">Stefan Guilhen</a>
+ */
+public class DomainContextRealmService implements Service<SecurityRealm> {
+
+    private volatile SecurityRealm securityRealm;
+
+    private InjectedValue<SecurityDomainContext> securityDomainContextInjector = new InjectedValue<>();
+
+    @Override
+    public void start(final StartContext startContext) throws StartException {
+        final SecurityDomainContext context = this.securityDomainContextInjector.getValue();
+        this.securityRealm = new DomainContextRealm(context);
+    }
+
+    @Override
+    public void stop(final StopContext stopContext) {
+        this.securityRealm = null;
+    }
+
+    @Override
+    public SecurityRealm getValue() throws IllegalStateException, IllegalArgumentException {
+        return this.securityRealm;
+    }
+
+    public Injector<SecurityDomainContext> getSecurityDomainContextInjector() {
+        return this.securityDomainContextInjector;
+    }
+}

--- a/security/subsystem/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
+++ b/security/subsystem/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
@@ -8,6 +8,7 @@ security-domain=Configures a security domain. Authentication, authorization, ACL
 security-domain.add=Add a security domain.
 security-domain.remove=Remove a security domain.
 security-domain.cache-type=Adds a cache to speed up authentication checks. Allowed values are 'default' to use simple map as the cache and 'infinispan' to use an Infinispan cache.
+security-domain.export-elytron-realm=Indicates if an Elytron compatible realm should be exported as a capability by the security domain.
 security-domain.module-options=Module options
 authentication="Authentication configuration for this domain. Can either be classic or jaspi.
 authentication.classic=Traditional authentication configuration.  Configures a list of login modules to be used.

--- a/security/subsystem/src/main/resources/schema/jboss-as-security_2_0.xsd
+++ b/security/subsystem/src/main/resources/schema/jboss-as-security_2_0.xsd
@@ -99,7 +99,7 @@
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required"/>
       <xs:attribute name="cache-type" type="xs:string" use="optional"/>
-      <xs:attribute name="export-elytron-realm" type="xs:boolean" use="optional"/>
+      <xs:attribute name="export-elytron-realm" type="xs:string" use="optional"/>
    </xs:complexType>
 
    <xs:complexType name="authenticationType">

--- a/security/subsystem/src/main/resources/schema/jboss-as-security_2_0.xsd
+++ b/security/subsystem/src/main/resources/schema/jboss-as-security_2_0.xsd
@@ -1,0 +1,424 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:security:2.0"
+           xmlns="urn:jboss:domain:security:2.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="2.0">
+
+   <!-- The security subsystem root element -->
+   <xs:element name="subsystem" type="security-containerType" />
+
+   <!-- The security container configuration -->
+   <xs:complexType name="security-containerType">
+      <xs:annotation>
+         <xs:documentation>
+                <![CDATA[
+                    The security subsystem, used to configure authentication and authorization.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element name="security-management" type="securityManagementType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="security-domains" type="securityDomainsType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+   </xs:complexType>
+
+   <!-- The security management element -->
+   <xs:complexType name="securityManagementType">
+      <xs:annotation>
+         <xs:documentation>
+                <![CDATA[
+                    The optional "deep-copy-subject-mode" attribute sets the copy mode of subjects done by the security
+                    managers to be deep copies that makes copies of the subject principals and credentials if they are
+                    cloneable. It should be set to true if subject include mutable content that can be corrupted when
+                    multiple threads have the same identity and cache flushes/logout clearing the subject in one thread
+                    results in subject references affecting other threads. Default value is "false".
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:attribute name="deep-copy-subject-mode" type="xs:boolean" use="optional"/>
+   </xs:complexType>
+
+   <!-- Configuration for security domains -->
+   <xs:complexType name="securityDomainsType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Configures security domains for applications.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="security-domain" type="securityDomainType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="securityDomainType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Definition of a security domain.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="authentication" type="authenticationType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="authentication-jaspi" type="authenticationJaspiType" minOccurs="0" maxOccurs="1"/>
+         </xs:choice>
+         <xs:element name="authorization" type="authorizationType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="acl" type="aclType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="mapping" type="mappingType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="audit" type="auditType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="identity-trust" type="identityTrustType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="jsse" type="jsseType" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+      <xs:attribute name="cache-type" type="xs:string" use="optional"/>
+      <xs:attribute name="export-elytron-realm" type="xs:boolean" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="authenticationType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authentication configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="login-module" type="loginModuleType" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="authenticationJaspiType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    JASPI authentication configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="login-module-stack" type="loginModuleStackType" maxOccurs="unbounded"/>
+         <xs:element name="auth-module" type="authModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="authorizationType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authorization configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="policy-module" type="policyModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="aclType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    ACL configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="acl-module" type="aclModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="mappingType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Mapping configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="mapping-module" type="mappingModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="auditType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Audit configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="provider-module" type="providerModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="identityTrustType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Identity trust configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="trust-module" type="trustModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:simpleType name="module-option-flag">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    The flag attribute controls how a login module
+                    participates in the overall procedure.
+                    Required - The LoginModule is required to succeed. If it
+                    succeeds or fails, authentication still continues to proceed
+                    down the LoginModule list.
+
+                    Requisite - The LoginModule is required to succeed. If it succeeds,
+                    authentication continues down the LoginModule list. If it fails,
+                    control immediately returns to the application (authentication does not proceed
+                    down the LoginModule list).
+
+                    Sufficient - The LoginModule is  not required to succeed. If it does
+                    succeed, control immediately returns to the application (authentication
+                    does not proceed down the LoginModule list). If it fails,
+                    authentication continues down the LoginModule list.
+
+                    Optional - The LoginModule is not required to succeed. If it succeeds or
+                    fails, authentication still continues to proceed down the
+                    LoginModule list.
+
+                    The overall authentication succeeds only if
+                    all required and requisite LoginModules succeed. If a
+                    sufficient LoginModule is configured and succeeds, then only
+                    the required and requisite LoginModules prior to that
+                    sufficient LoginModule need to have succeeded for the overall
+                    authentication to succeed. If no required or requisite
+                    LoginModules are configured for an application, then at least
+                    one sufficient or optional LoginModule must succeed.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="required"/>
+         <xs:enumeration value="requisite"/>
+         <xs:enumeration value="sufficient"/>
+         <xs:enumeration value="optional"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="loginModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Login module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="propertyType">
+      <xs:attribute name="name" type="xs:string" use="required"/>
+      <xs:attribute name="value" type="xs:string" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="loginModuleStackType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Login module configuration for JASPI.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="login-module" type="loginModuleType" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="authModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authentication module configuration for JASPI.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="optional"/>
+      <xs:attribute name="login-module-stack-ref" type="xs:string" use="optional"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="policyModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authorization module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="aclModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    ACL module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="mappingModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Mapping module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="type" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="providerModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Audit module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="trustModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Identity trust module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="jsseType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    JSSE configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+        <xs:element name="property" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="keystore-password" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-type" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-url" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-provider-argument" type="xs:string" use="optional"/>
+      <xs:attribute name="key-manager-factory-algorithm" type="xs:string" use="optional"/>
+      <xs:attribute name="key-manager-factory-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-password" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-type" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-url" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-provider-argument" type="xs:string" use="optional"/>
+      <xs:attribute name="trust-manager-factory-algorithm" type="xs:string" use="optional"/>
+      <xs:attribute name="trust-manager-factory-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="client-alias" type="xs:string" use="optional"/>
+      <xs:attribute name="server-alias" type="xs:string" use="optional"/>
+      <xs:attribute name="service-auth-token" type="xs:string" use="optional"/>
+      <xs:attribute name="client-auth" type="xs:boolean" use="optional"/>
+      <xs:attribute name="cipher-suites" type="xs:string" use="optional"/>
+      <xs:attribute name="protocols" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="vaultType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Vault Configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="vault-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="optional"/>
+   </xs:complexType>
+</xs:schema>

--- a/security/subsystem/src/main/resources/subsystem-templates/security.xml
+++ b/security/subsystem/src/main/resources/subsystem-templates/security.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.security</extension-module>
-   <subsystem xmlns="urn:jboss:domain:security:1.2">
+   <subsystem xmlns="urn:jboss:domain:security:2.0">
        <security-domains>
            <security-domain name="other" cache-type="default">
                <authentication>

--- a/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
+++ b/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
@@ -52,6 +52,7 @@ import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.SingleClassFilter;
 import org.jboss.as.security.logging.SecurityLogger;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
@@ -67,71 +68,15 @@ import org.junit.Test;
  * Security subsystem tests for the version 1.2 of the subsystem schema.
  * </p>
  */
-public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTest {
-
-    private static String oldConfig;
-    @BeforeClass
-    public static void beforeClass() {
-        try {
-            File target = new File(SecurityDomainModelv11UnitTestCase.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile();
-            File config = new File(target, "config");
-            config.mkdir();
-            oldConfig = System.setProperty("jboss.server.config.dir", config.getAbsolutePath());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        if (oldConfig != null) {
-            System.setProperty("jboss.server.config.dir", oldConfig);
-        } else {
-            System.clearProperty("jboss.server.config.dir");
-        }
-    }
+public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemTest {
 
     public SecurityDomainModelv12UnitTestCase() {
         super(SecurityExtension.SUBSYSTEM_NAME, new SecurityExtension());
     }
 
-    @Override
-    protected AdditionalInitialization createAdditionalInitialization() {
-        return new AdditionalInitialization() {
-            @Override
-            protected RunningMode getRunningMode() {
-                return RunningMode.NORMAL;
-            }
-        };
-    }
-
-    @Override
-    protected String getSubsystemXml() throws IOException {
-        return readResource("securitysubsystemv12.xml");
-    }
-
-    @Override
-    protected String getSubsystemXsdPath() throws Exception {
-        return "schema/jboss-as-security_1_2.xsd";
-    }
-
-    @Override
-    protected String[] getSubsystemTemplatePaths() throws IOException {
-        return new String[] {
-                "/subsystem-templates/security.xml"
-        };
-    }
-
-    @Override
-    protected Properties getResolvedProperties() {
-        Properties properties = new Properties();
-        properties.put("jboss.server.config.dir", System.getProperty("java.io.tmpdir"));
-        return properties;
-    }
-
     @Test
     public void testOrder() throws Exception {
-        KernelServices service = createKernelServicesBuilder(createAdditionalInitialization())
+        KernelServices service = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource("securitysubsystemv12.xml")
                 .build();
         PathAddress address = PathAddress.pathAddress().append("subsystem", "security").append("security-domain", "ordering");

--- a/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv20UnitTestCase.java
+++ b/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv20UnitTestCase.java
@@ -1,0 +1,131 @@
+/*
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2015, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SecurityDomainModelv20UnitTestCase extends AbstractSubsystemBaseTest {
+
+    public SecurityDomainModelv20UnitTestCase() {
+        super(SecurityExtension.SUBSYSTEM_NAME, new SecurityExtension());
+    }
+
+    private static String oldConfig;
+
+
+    @BeforeClass
+    public static void beforeClass() {
+        try {
+            File target = new File(SecurityDomainModelv20UnitTestCase.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile();
+            File config = new File(target, "config");
+            config.mkdir();
+            oldConfig = System.setProperty("jboss.server.config.dir", config.getAbsolutePath());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (oldConfig != null) {
+            System.setProperty("jboss.server.config.dir", oldConfig);
+        } else {
+            System.clearProperty("jboss.server.config.dir");
+        }
+    }
+
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("securitysubsystemv20.xml");
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws Exception {
+        return "schema/jboss-as-security_2_0.xsd";
+    }
+
+    @Override
+    protected String[] getSubsystemTemplatePaths() throws IOException {
+        return new String[] {
+                "/subsystem-templates/security.xml"
+        };
+    }
+
+    @Override
+    protected Properties getResolvedProperties() {
+        Properties properties = new Properties();
+        properties.put("jboss.server.config.dir", System.getProperty("java.io.tmpdir"));
+        return properties;
+    }
+
+    @Test
+    public void testTransformersEAP64() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_6_4_0);
+    }
+
+    private void testTransformers(ModelTestControllerVersion controllerVersion) throws Exception {
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        ModelVersion version = ModelVersion.create(1, 3, 0);
+        builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, version)
+                .addMavenResourceURL("org.jboss.as:jboss-as-security:" + controllerVersion.getMavenGavVersion());
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(version);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+        // the elytron domain should be rejected because it has defined the export-elytron-realm attribute as true.
+        PathAddress domainAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement(Constants.SECURITY_DOMAIN, "elytron"));
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version,
+                builder.parseXmlResource("securitysubsystemv20.xml"),
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(PathAddress.pathAddress(domainAddress),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
+
+        // we should not get any errors for the other2 domain - the export-elytron-realm attribute has been set to false,
+        // making it compatible with older versions of the model.
+    }
+}

--- a/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv20UnitTestCase.java
+++ b/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv20UnitTestCase.java
@@ -118,14 +118,11 @@ public class SecurityDomainModelv20UnitTestCase extends AbstractSubsystemBaseTes
         assertTrue(legacyServices.isSuccessfulBoot());
 
         // the elytron domain should be rejected because it has defined the export-elytron-realm attribute as true.
-        PathAddress domainAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement(Constants.SECURITY_DOMAIN, "elytron"));
+        PathAddress domainAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement(Constants.SECURITY_DOMAIN, "legacy-domain"));
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version,
                 builder.parseXmlResource("securitysubsystemv20.xml"),
                 new FailedOperationTransformationConfig()
                         .addFailedAttribute(PathAddress.pathAddress(domainAddress),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE));
-
-        // we should not get any errors for the other2 domain - the export-elytron-realm attribute has been set to false,
-        // making it compatible with older versions of the model.
     }
 }

--- a/security/subsystem/src/test/resources/org/jboss/as/security/securityExpressions.xml
+++ b/security/subsystem/src/test/resources/org/jboss/as/security/securityExpressions.xml
@@ -22,7 +22,7 @@
   ~
   -->
 
-<subsystem xmlns="urn:jboss:domain:security:1.2">
+<subsystem xmlns="urn:jboss:domain:security:2.0">
     <security-domains>
         <security-domain name="other" cache-type="default">
             <authentication>

--- a/security/subsystem/src/test/resources/org/jboss/as/security/securitysubsystemv20.xml
+++ b/security/subsystem/src/test/resources/org/jboss/as/security/securitysubsystemv20.xml
@@ -109,7 +109,7 @@
                 </login-module>
             </authentication>
         </security-domain>
-        <security-domain name="other2" cache-type="default" export-elytron-realm="false">
+        <security-domain name="other2" cache-type="default">
             <authentication>
                 <login-module code="Remoting" flag="optional">
                     <module-option name="password-stacking" value="useFirstPass"/>
@@ -132,7 +132,7 @@
         <security-domain name="jboss-empty-jsse" >
             <jsse server-alias="silent.planet" />
         </security-domain>
-       <security-domain name="elytron" cache-type="none" export-elytron-realm="true"/>
+       <security-domain name="legacy-domain" cache-type="none" export-elytron-realm="legacy-realm"/>
     </security-domains>
    <vault code="somevault">
      <vault-option name="xyz" value="zxc"/>

--- a/security/subsystem/src/test/resources/org/jboss/as/security/securitysubsystemv20.xml
+++ b/security/subsystem/src/test/resources/org/jboss/as/security/securitysubsystemv20.xml
@@ -1,0 +1,141 @@
+<!--
+  ~
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~
+  -->
+
+<subsystem xmlns="urn:jboss:domain:security:2.0">
+   <security-domains>
+      <security-domain name="other" cache-type="default">
+             <authentication>
+                <login-module code="Remoting" flag="${test.prop:optional}" module="test-authentication">
+                  <module-option name="password-stacking" value="${test.prop:useFirstPass}"/>
+                </login-module>
+                 <login-module code="Duplicate" flag="optional" />
+                 <login-module name="duplicate-module" code="Duplicate" flag="optional" />
+                <login-module code="Anon" flag="optional"/>
+                <login-module code="RealmUsersRoles" flag="required">
+                  <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                  <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                  <module-option name="realm" value="ApplicationRealm"/>
+                  <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+              </authentication>
+         <authorization>
+            <policy-module code="DenyAll" flag="${test.prop:required}" module="test-auth">
+                 <module-option name="a" value="${test.prop:c}"/>
+               </policy-module>
+         </authorization>
+         <acl>
+            <acl-module name="acl" code="AclThingy" flag="${test.prop:required}" module="test">
+                 <module-option name="d" value="${test.prop:r}"/>
+            </acl-module>
+         </acl>
+         <mapping>
+           <mapping-module name="test" code="SimpleRoles" type="${test.prop:role}" module="test-mapping">
+                 <module-option name="d" value="${test.prop:e}"/>
+           </mapping-module>
+         </mapping>
+         <audit>
+                 <provider-module code="customModule">
+                   <module-option name="d" value="${test.prop:r}"/>
+                 </provider-module>
+         </audit>
+         <identity-trust>
+             <trust-module code="IdentityThingy" flag="${test.prop:required}" module="test-identity">
+                 <module-option name="d" value="${test.prop:r}"/>
+             </trust-module>
+         </identity-trust>
+         <jsse truststore-url="${test.prop:keystore.jks}"
+                  truststore-password="${test.prop:rmi+ssl}"
+                  truststore-type="${test.prop:jks}"
+                  truststore-provider="${test.prop:truststore.jks}"
+                  truststore-provider-argument="${test.prop:trust-arg}"
+                  trust-manager-factory-algorithm="${test.prop:JKS}"
+                  trust-manager-factory-provider="${test.prop:JKS-provider}"
+                  keystore-url="${test.prop:clientcert.jks}"
+                  keystore-password="${test.prop:changeit}"
+                  keystore-type="${test.prop:jks2}"
+                  keystore-provider="${test.prop:keystore.jks}"
+                  keystore-provider-argument="${test.prop:key-arg}"
+                  key-manager-factory-algorithm="${test.prop:JKS}"
+                  key-manager-factory-provider="${test.prop:JKS-provider}"
+                  client-alias="${test.prop:client-alias}"
+                  server-alias="${test.prop:server-alias}"
+                  service-auth-token="${test.prop:server-auth-token}"
+                  client-auth="${test.prop:true}"
+                  cipher-suites="${test.prop:aaa,bbb,ccc}"
+                  protocols="${test.prop:one,two,three}">
+                <property name="name" value="${some.prop:default}"/>
+         </jsse>
+      </security-domain>
+        <security-domain name="jaspi-test" cache-type="default">
+            <authentication-jaspi>
+                <login-module-stack name="lm-stack">
+                    <login-module name="lm" code="UsersRoles" flag="required" module="test-jaspi">
+                        <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                        <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                    </login-module>
+                </login-module-stack>
+                <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
+                             flag="${test.prop:optional}" module="test-jaspi">
+                   <module-option name="x" value="${test.prop:y}"/>
+                   <module-option name="p" value="${test.prop:r}"/>
+                </auth-module>
+            </authentication-jaspi>
+        </security-domain>
+        <security-domain name="ordering" cache-type="default">
+            <authentication>
+                <login-module code="Remoting" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+            </authentication>
+        </security-domain>
+        <security-domain name="other2" cache-type="default" export-elytron-realm="false">
+            <authentication>
+                <login-module code="Remoting" flag="optional">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmDirect" flag="required">
+                    <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+            </authentication>
+        </security-domain>
+        <security-domain name="jboss-web-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <security-domain name="jboss-ejb-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="required"/>
+            </authorization>
+        </security-domain>
+        <security-domain name="jboss-empty-jsse" >
+            <jsse server-alias="silent.planet" />
+        </security-domain>
+       <security-domain name="elytron" cache-type="none" export-elytron-realm="true"/>
+    </security-domains>
+   <vault code="somevault">
+     <vault-option name="xyz" value="zxc"/>
+     <vault-option name="abc" value="def"/>
+    </vault>
+</subsystem>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebCERTTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebCERTTestsSecurityDomainSetup.java
@@ -106,12 +106,19 @@ public class WebCERTTestsSecurityDomainSetup extends AbstractSecurityRealmsServe
             URL roles = getClass().getResource("cert/roles.properties");
 
             final List<ModelNode> updates = new ArrayList<ModelNode>();
-            PathAddress address = PathAddress.pathAddress().append(SUBSYSTEM, "security")
+
+            final ModelNode compositeOp = new ModelNode();
+            compositeOp.get(OP).set(COMPOSITE);
+            compositeOp.get(OP_ADDR).setEmptyList();
+
+            final ModelNode domainSteps = compositeOp.get(STEPS);
+            PathAddress address = PathAddress.pathAddress()
+                    .append(SUBSYSTEM, "security")
                     .append(SECURITY_DOMAIN, APP_SECURITY_DOMAIN);
 
-            updates.add(Util.createAddOperation(address));
+            domainSteps.add(Util.createAddOperation(address));
             address = address.append(Constants.AUTHENTICATION, Constants.CLASSIC);
-            updates.add(Util.createAddOperation(address));
+            domainSteps.add(Util.createAddOperation(address));
 
             ModelNode loginModule = Util.createAddOperation(address.append(LOGIN_MODULE, "CertificateRoles"));
             loginModule.get(CODE).set("CertificateRoles");
@@ -119,21 +126,18 @@ public class WebCERTTestsSecurityDomainSetup extends AbstractSecurityRealmsServe
             ModelNode moduleOptions = loginModule.get(MODULE_OPTIONS);
             moduleOptions.add("securityDomain", APP_SECURITY_DOMAIN);
             moduleOptions.add("rolesProperties", roles.getPath());
-            loginModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-
-            updates.add(loginModule);
+            //loginModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            domainSteps.add(loginModule);
 
             // Add the JSSE security domain.
             address = PathAddress.pathAddress().append(SUBSYSTEM, "security").append(SECURITY_DOMAIN, APP_SECURITY_DOMAIN);
-
             ModelNode op = Util.createAddOperation(address.append(JSSE, Constants.CLASSIC));
-
             op.get(TRUSTSTORE, PASSWORD).set("changeit");
-
             op.get(TRUSTSTORE, URL).set(keystore.getPath());
-            op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-            updates.add(op);
+            //op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            domainSteps.add(op);
 
+            updates.add(compositeOp);
             // Add the HTTPS socket binding.
             op = new ModelNode();
             op.get(OP).set(ADD);


### PR DESCRIPTION
…ecurity domain context for authentication.
- Realm is exported as a capability if the export-elytron-realm attribute is set to true in the security domain configuration.
- Handlers used by the domain sub resources have been updated to remove the additional capability before reloading the services.
- Transformer has been added to reject the new attribute if it is set to true and discard it if set to false.
- Requires PicketBox upgrade in wildfly-core (to version 5.0.0.Alpha1 or later)
