### PR TITLE
[WFLY-5689] EJB subsystem security domain mapping

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -70,6 +70,7 @@ import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.requestcontroller.ControlPoint;
+import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -117,6 +118,8 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
             return serverSecurityManager.getCallerPrincipal();
         }
     };
+
+    private final Map<String, SecurityDomain> securityDomainsByName;
 
     /**
      * Construct a new instance.
@@ -168,6 +171,8 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
         this.serverSecurityManager = ejbComponentCreateService.getServerSecurityManager();
         this.controlPoint = ejbComponentCreateService.getControlPoint();
         this.exceptionLoggingEnabled = ejbComponentCreateService.getExceptionLoggingEnabled();
+
+        this.securityDomainsByName = ejbComponentCreateService.getSecurityDomainsByName();
     }
 
     protected <T> T createViewInstanceProxy(final Class<T> viewInterface, final Map<Object, Object> contextData) {
@@ -533,6 +538,10 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
 
     public ControlPoint getControlPoint() {
         return this.controlPoint;
+    }
+
+    public Map<String, SecurityDomain> getSecurityDomainsByName() {
+        return securityDomainsByName;
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -59,6 +59,7 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.requestcontroller.ControlPoint;
+import org.wildfly.security.auth.server.SecurityDomain;
 
 /**
  * @author Jaikiran Pai
@@ -102,6 +103,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();
     private final InjectedValue<ControlPoint> controlPoint = new InjectedValue<>();
     private final InjectedValue<AtomicBoolean> exceptionLoggingEnabled = new InjectedValue<>();
+    private final InjectedValue<Map<String, SecurityDomain>> securityDomainsByName = new InjectedValue<>();
 
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
 
@@ -382,6 +384,14 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     public AtomicBoolean getExceptionLoggingEnabled() {
         return exceptionLoggingEnabled.getValue();
+    }
+
+    InjectedValue<Map<String, SecurityDomain>> getSecurityDomainsByNameInjector() {
+        return securityDomainsByName;
+    }
+
+    public Map<String, SecurityDomain> getSecurityDomainsByName() {
+        return securityDomainsByName.getValue();
     }
 
     public ShutDownInterceptorFactory getShutDownInterceptorFactory() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
@@ -44,6 +44,7 @@ import static org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION;
 public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcessor {
 
     private volatile String defaultSecurityDomainName;
+    private volatile boolean securityDomainsConfigured;
 
     public EJBDefaultSecurityDomainProcessor(final String defaultSecurityDomainName) {
         this.defaultSecurityDomainName = defaultSecurityDomainName;
@@ -70,6 +71,7 @@ public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcesso
         for (ComponentDescription componentDescription : componentDescriptions) {
             if (componentDescription instanceof EJBComponentDescription) {
                 ((EJBComponentDescription) componentDescription).setDefaultSecurityDomain(defaultSecurityDomain);
+                ((EJBComponentDescription) componentDescription).setSecurityDomainsConfigured(securityDomainsConfigured);
             }
         }
     }
@@ -86,5 +88,14 @@ public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcesso
      */
     public void setDefaultSecurityDomainName(final String securityDomainName) {
         this.defaultSecurityDomainName = securityDomainName;
+    }
+
+    /**
+     * Sets whether or not security domains are explicitly configured in the EJB3 subsystem.
+     *
+     * @param securityDomainsConfigured whether or not security domains are explicitly configured in the EJB3 subsystem
+     */
+    public void setSecurityDomainsConfigured(final boolean securityDomainsConfigured) {
+        this.securityDomainsConfigured = securityDomainsConfigured;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3111,4 +3111,7 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 484, value = "Could not send a cluster removal message for cluster: (%s) to the client on channel %s")
     void couldNotSendClusterRemovalMessage(@Cause Throwable cause, Group group, Channel channel);
+
+    @Message(id = 485, value = "The default security domain '%s' is not in the list of referenced security domains.")
+    OperationFailedException defaultSecurityDomainNotReferenced(String defaultSecurityDomain);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem14Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem14Parser.java
@@ -68,7 +68,7 @@ public class EJB3Subsystem14Parser extends EJB3Subsystem13Parser {
         return EJB3SubsystemNamespace.EJB3_1_4;
     }
 
-    private void parseDefaultSecurityDomain(final XMLExtendedStreamReader reader, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+    protected void parseDefaultSecurityDomain(final XMLExtendedStreamReader reader, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
         final int count = reader.getAttributeCount();
         final EnumSet<EJB3SubsystemXMLAttribute> missingRequiredAttributes = EnumSet.of(EJB3SubsystemXMLAttribute.VALUE);
         for (int i = 0; i < count; i++) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem50Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem50Parser.java
@@ -22,6 +22,26 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequiredElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SECURITY_DOMAINS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
  * Parser for ejb3:5.0 namespace.
@@ -40,4 +60,92 @@ public class EJB3Subsystem50Parser extends EJB3Subsystem40Parser {
         return EJB3SubsystemNamespace.EJB3_5_0;
     }
 
+    @Override
+    protected void readElement(final XMLExtendedStreamReader reader, final EJB3SubsystemXMLElement element, final List<ModelNode> operations, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+        switch (element) {
+            case SECURITY_DOMAINS: {
+                parseSecurityDomains(reader, ejb3SubsystemAddOperation);
+                break;
+            }
+            case DEFAULT_SECURITY_DOMAIN: {
+                if ((ejb3SubsystemAddOperation.hasDefined(SECURITY_DOMAINS)) && (ejb3SubsystemAddOperation.hasDefined(DEFAULT_SECURITY_DOMAIN))) {
+                    // Already defined using the security-domains default attribute
+                    throw unexpectedElement(reader);
+                }
+                parseDefaultSecurityDomain(reader, ejb3SubsystemAddOperation);
+                break;
+            }
+            default: {
+                super.readElement(reader, element, operations, ejb3SubsystemAddOperation);
+            }
+        }
+    }
+
+    private void parseSecurityDomains(final XMLExtendedStreamReader reader, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String attributeValue = reader.getAttributeValue(i);
+            final EJB3SubsystemXMLAttribute attribute = EJB3SubsystemXMLAttribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case DEFAULT: {
+                    if (ejb3SubsystemAddOperation.hasDefined(DEFAULT_SECURITY_DOMAIN)) {
+                        // Already defined using the default-security-domain element
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN.parseAndSetParameter(attributeValue, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
+                default: {
+                    throw unexpectedAttribute(reader, i);
+                }
+            }
+        }
+        final Set<String> securityDomainNames = new HashSet<String>();
+        while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
+            switch (EJB3SubsystemXMLElement.forName(reader.getLocalName())) {
+                case SECURITY_DOMAIN: {
+                    parseSecurityDomain(reader, ejb3SubsystemAddOperation, securityDomainNames);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+        if (securityDomainNames.isEmpty()) {
+            throw missingRequiredElement(reader, Collections.singleton(EJB3SubsystemXMLElement.SECURITY_DOMAIN.getLocalName()));
+        }
+    }
+
+    private void parseSecurityDomain(final XMLExtendedStreamReader reader, final ModelNode ejb3SubsystemAddOperation,
+                                     final Set<String> securityDomainNames) throws XMLStreamException {
+        String securityDomainName = null;
+        ModelNode securityDomain = new ModelNode();
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String attributeValue = reader.getAttributeValue(i);
+            final EJB3SubsystemXMLAttribute attribute = EJB3SubsystemXMLAttribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case NAME:
+                    securityDomainName = attributeValue;
+                    if (! securityDomainNames.add(securityDomainName)) {
+                        throw duplicateNamedElement(reader, securityDomainName);
+                    }
+                    EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_NAME.parseAndSetParameter(securityDomainName, securityDomain, reader);
+                    break;
+                case ALIAS:
+                    EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_ALIAS.parseAndSetParameter(attributeValue, securityDomain, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (securityDomainName == null) {
+            throw missingRequired(reader, Collections.singleton(EJB3SubsystemXMLAttribute.NAME.getLocalName()));
+        }
+        requireNoContent(reader);
+        ejb3SubsystemAddOperation.get(SECURITY_DOMAINS).add(securityDomain);
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -22,15 +22,19 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import java.util.List;
+import java.util.Map;
+
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.ejb3.cache.CacheFactoryBuilderRegistryService;
@@ -101,6 +105,7 @@ import org.jboss.as.ejb3.deployment.processors.security.JaccEjbDeploymentProcess
 import org.jboss.as.ejb3.iiop.POARegistry;
 import org.jboss.as.ejb3.iiop.RemoteObjectSubstitutionService;
 import org.jboss.as.ejb3.iiop.stub.DynamicStubFactoryFactory;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
 import org.jboss.as.ejb3.remote.EJBRemoteConnectorService;
 import org.jboss.as.ejb3.remote.EJBTransactionRecoveryService;
@@ -127,15 +132,18 @@ import org.jboss.ejb.client.naming.ejb.ejbURLContextFactory;
 import org.jboss.javax.rmi.RemoteObjectSubstitutionManager;
 import org.jboss.jca.core.spi.rar.ResourceAdapterRepository;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
+import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceBuilder.DependencyType;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.omg.PortableServer.POA;
 import org.wildfly.clustering.singleton.SingletonPolicy;
 import org.wildfly.iiop.openjdk.rmi.DelegatingStubFactoryFactory;
 import org.wildfly.iiop.openjdk.service.CorbaPOAService;
+import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 import javax.transaction.TransactionManager;
@@ -152,6 +160,12 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_B
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.CLUSTERED_SINGLETON_CAPABILITY;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.SECURITY_DOMAINS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.SECURITY_DOMAINS_CAPABILITY;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_ALIAS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_CAPABILITY;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_NAME;
 
 /**
  * Add operation handler for the EJB3 subsystem.
@@ -172,16 +186,38 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         // TODO: delete this once optional requirements no longer require the existence of a capability
         context.registerCapability(CLUSTERED_SINGLETON_CAPABILITY, null);
+
+        context.registerCapability(SECURITY_DOMAINS_CAPABILITY, null);
     }
 
     @Override
     protected void populateModel(final OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         ModelNode model = resource.getModel();
-        for (SimpleAttributeDefinition attr : EJB3SubsystemRootResourceDefinition.ATTRIBUTES) {
+        for (AttributeDefinition attr : EJB3SubsystemRootResourceDefinition.ATTRIBUTES) {
             attr.validateAndSet(operation, model);
         }
         if (context.getProcessType().isServer()) {
             context.addStep(new ValidateClusteredCacheRefHandler(), OperationContext.Stage.MODEL);
+        }
+
+        // Validate the default security domain
+        final ModelNode defaultSecurityDomainModelNode = DEFAULT_SECURITY_DOMAIN.resolveModelAttribute(context, model);
+        final String defaultSecurityDomain = defaultSecurityDomainModelNode.isDefined() ? defaultSecurityDomainModelNode.asString() : null;
+        if (defaultSecurityDomain != null) {
+            if (model.hasDefined(EJB3SubsystemModel.SECURITY_DOMAINS)) {
+                List<ModelNode> securityDomains = SECURITY_DOMAINS.resolveModelAttribute(context, model).asList();
+                boolean defaultFound = false;
+                for (ModelNode current : securityDomains) {
+                    String securityDomainName = SECURITY_DOMAIN_NAME.resolveModelAttribute(context, current).asString();
+                    if (defaultSecurityDomain.equals(securityDomainName)) {
+                        defaultFound = true;
+                        break;
+                    }
+                }
+                if (!defaultFound) {
+                    throw EjbLogger.ROOT_LOGGER.defaultSecurityDomainNotReferenced(defaultSecurityDomain);
+                }
+            }
         }
     }
 
@@ -211,10 +247,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         final DefaultDistinctNameService defaultDistinctNameService = new DefaultDistinctNameService(defaultDistinctName.isDefined() ? defaultDistinctName.asString() : null);
         context.getServiceTarget().addService(DefaultDistinctNameService.SERVICE_NAME, defaultDistinctNameService).install();
 
-        // set the default security domain name in the deployment unit processor, configured at the subsytem level
-        final ModelNode defaultSecurityDomainModelNode = EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN.resolveModelAttribute(context, model);
-        final String defaultSecurityDomain = defaultSecurityDomainModelNode.isDefined() ? defaultSecurityDomainModelNode.asString() : null;
-        this.defaultSecurityDomainDeploymentProcessor.setDefaultSecurityDomainName(defaultSecurityDomain);
+        addSecurityDomainsServiceAndConfigureDefaultDomain(context, model);
 
         // set the default security domain name in the deployment unit processor, configured at the subsytem level
         final ModelNode defaultMissingMethod = EJB3SubsystemRootResourceDefinition.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS.resolveModelAttribute(context, model);
@@ -460,6 +493,38 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     .addDependency(context.getCapabilityServiceName(SingletonPolicy.CAPABILITY_NAME, SingletonPolicy.class),
                             SingletonPolicy.class, singletonBarrierCreator.getSingletonPolicy()).install();
         }
+    }
+
+    private void addSecurityDomainsServiceAndConfigureDefaultDomain(final OperationContext context, final ModelNode ejbSubsystemModel) throws OperationFailedException {
+        final ServiceName securityDomainsServiceName = SECURITY_DOMAINS_CAPABILITY.getCapabilityServiceName();
+        final SecurityDomainsService securityDomainsService = new SecurityDomainsService();
+        final ServiceTarget target = context.getServiceTarget();
+        final ServiceBuilder<Map<String, SecurityDomain>> securityDomainsServiceBuilder = target.addService(securityDomainsServiceName, securityDomainsService);
+
+        final ModelNode defaultSecurityDomainModelNode = DEFAULT_SECURITY_DOMAIN.resolveModelAttribute(context, ejbSubsystemModel);
+        String defaultSecurityDomain = defaultSecurityDomainModelNode.isDefined() ? defaultSecurityDomainModelNode.asString() : null;
+
+        if (ejbSubsystemModel.hasDefined(EJB3SubsystemModel.SECURITY_DOMAINS)) {
+            this.defaultSecurityDomainDeploymentProcessor.setSecurityDomainsConfigured(true);
+            final List<ModelNode> securityDomains = SECURITY_DOMAINS.resolveModelAttribute(context, ejbSubsystemModel).asList();
+            for (ModelNode current : securityDomains) {
+                final String securityDomainName = SECURITY_DOMAIN_NAME.resolveModelAttribute(context, current).asString();
+                final ModelNode securityDomainAliasModelNode = SECURITY_DOMAIN_ALIAS.resolveModelAttribute(context, current);
+                final String securityDomainAlias = securityDomainAliasModelNode.isDefined() ? securityDomainAliasModelNode.asString() : securityDomainName;
+                if ((defaultSecurityDomain != null) && (defaultSecurityDomain.equals(securityDomainName))) {
+                    defaultSecurityDomain = securityDomainAlias; // Use the corresponding alias as the default name instead
+                }
+                final String runtimeCapability = RuntimeCapability.buildDynamicCapabilityName(SECURITY_DOMAIN_CAPABILITY, securityDomainName);
+                final ServiceName securityDomainServiceName = context.getCapabilityServiceName(runtimeCapability, SecurityDomain.class);
+                final Injector<SecurityDomain> injector = securityDomainsService.createSecurityDomainInjector(securityDomainAlias);
+                if (injector != null) {
+                    securityDomainsServiceBuilder.addDependency(securityDomainServiceName, SecurityDomain.class, injector);
+                }
+            }
+        }
+        // Set the default security domain name in the deployment unit processor
+        this.defaultSecurityDomainDeploymentProcessor.setDefaultSecurityDomainName(defaultSecurityDomain);
+        securityDomainsServiceBuilder.install();
     }
 
     private static boolean isEJBRemoteConnectorInstalled(final OperationContext context) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -43,6 +43,8 @@ public interface EJB3SubsystemModel {
     String DATASOURCE_JNDI_NAME = "datasource-jndi-name";
     String DEFAULT_DISTINCT_NAME = "default-distinct-name";
     String DEFAULT_SECURITY_DOMAIN = "default-security-domain";
+    String SECURITY_DOMAIN = "security-domain";
+    String SECURITY_DOMAINS = "security-domains";
     String DEFAULT_MDB_INSTANCE_POOL = "default-mdb-instance-pool";
     String DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS = "default-missing-method-permissions-deny-access";
     String DEFAULT_RESOURCE_ADAPTER_NAME = "default-resource-adapter-name";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRemove.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRemove.java
@@ -37,6 +37,7 @@ public class EJB3SubsystemRemove extends AbstractRemoveStepHandler {
     public static final EJB3SubsystemRemove INSTANCE = new EJB3SubsystemRemove();
 
     private EJB3SubsystemRemove() {
+        super(EJB3SubsystemRootResourceDefinition.SECURITY_DOMAINS_CAPABILITY);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
@@ -31,6 +31,7 @@ import java.util.Map;
 public enum EJB3SubsystemXMLAttribute {
     UNKNOWN(null),
 
+    ALIAS("alias"),
     ALIASES("aliases"),
     ALLOW_EXECUTION("allow-execution"),
 
@@ -45,6 +46,7 @@ public enum EJB3SubsystemXMLAttribute {
     CONNECTOR_REF("connector-ref"),
     CORE_THREADS("core-threads"),
 
+    DEFAULT("default"),
     DEFAULT_ACCESS_TIMEOUT("default-access-timeout"),
     DEFAULT_DATA_STORE("default-data-store"),
     DATABASE("database"),

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
@@ -80,6 +80,8 @@ public enum EJB3SubsystemXMLElement {
     RESOURCE_ADAPTER_NAME("resource-adapter-name"),
     RESOURCE_ADAPTER_REF("resource-adapter-ref"),
 
+    SECURITY_DOMAIN("security-domain"),
+    SECURITY_DOMAINS("security-domains"),
     SESSION_BEAN("session-bean"),
     SINGLETON("singleton"),
     STATEFUL("stateful"),

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -225,8 +225,16 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
             writer.writeEndElement();
         }
 
-        // default-security-domain element
-        if (model.hasDefined(DEFAULT_SECURITY_DOMAIN)) {
+        if (model.hasDefined(SECURITY_DOMAINS)) {
+            // security-domains element
+            writer.writeStartElement(EJB3SubsystemXMLElement.SECURITY_DOMAINS.getLocalName());
+            if (model.hasDefined(DEFAULT_SECURITY_DOMAIN)) {
+                writer.writeAttribute(EJB3SubsystemXMLAttribute.DEFAULT.getLocalName(), model.get(DEFAULT_SECURITY_DOMAIN).asString());
+            }
+            writeSecurityDomains(writer, model);
+            writer.writeEndElement();
+        } else if (model.hasDefined(DEFAULT_SECURITY_DOMAIN)) {
+            // default-security-domain element
             writer.writeStartElement(EJB3SubsystemXMLElement.DEFAULT_SECURITY_DOMAIN.getLocalName());
             writer.writeAttribute(EJB3SubsystemXMLAttribute.VALUE.getLocalName(), model.get(DEFAULT_SECURITY_DOMAIN).asString());
             writer.writeEndElement();
@@ -586,6 +594,20 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
             }
             writer.writeEndElement();
         }
+    }
+
+    private void writeSecurityDomains(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
+        List<ModelNode> securityDomains = model.get(SECURITY_DOMAINS).asList();
+        for (ModelNode current : securityDomains) {
+            writeSecurityDomain(writer, current);
+        }
+    }
+
+    private void writeSecurityDomain(final XMLExtendedStreamWriter writer, final ModelNode securityDomain) throws XMLStreamException {
+        writer.writeStartElement(SECURITY_DOMAIN);
+        EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_NAME.marshallAsAttribute(securityDomain, writer);
+        EJB3SubsystemRootResourceDefinition.SECURITY_DOMAIN_ALIAS.marshallAsAttribute(securityDomain, writer);
+        writer.writeEndElement();
     }
 
     private static void writeAttribute(XMLExtendedStreamWriter writer, ModelNode model, AttributeDefinition attribute) throws XMLStreamException {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBDefaultSecurityDomainWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBDefaultSecurityDomainWriteHandler.java
@@ -52,7 +52,7 @@ class EJBDefaultSecurityDomainWriteHandler extends AbstractWriteAttributeHandler
         final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
         updateDefaultSecurityDomainDeploymentProcessor(context, model);
 
-        return false;
+        return model.hasDefined(EJB3SubsystemModel.SECURITY_DOMAINS);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SecurityDomainsService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/SecurityDomainsService.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.security.auth.server.SecurityDomain;
+
+/**
+ * A {@link Service} that returns a mapping of security domains by name.
+ *
+ * <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class SecurityDomainsService implements Service<Map<String, SecurityDomain>> {
+
+    private final Map<String, InjectedValue<SecurityDomain>> injectedSecurityDomainsByName = new HashMap<>();
+    private volatile Map<String, SecurityDomain> securityDomainsByName;
+
+    @Override
+    public void start(final StartContext context) throws StartException {
+        if ((injectedSecurityDomainsByName != null) && ! injectedSecurityDomainsByName.isEmpty()) {
+            securityDomainsByName = new HashMap<>(injectedSecurityDomainsByName.size());
+            injectedSecurityDomainsByName.forEach((key, value) -> securityDomainsByName.put(key, value.getValue()));
+        }
+    }
+
+    @Override
+    public void stop(final StopContext context) {
+        securityDomainsByName = null;
+    }
+
+    @Override
+    public Map<String, SecurityDomain> getValue() throws IllegalStateException, IllegalArgumentException {
+        return securityDomainsByName == null ? Collections.<String, SecurityDomain>emptyMap() : Collections.unmodifiableMap(securityDomainsByName);
+    }
+
+    Injector<SecurityDomain> createSecurityDomainInjector(final String securityDomainAlias) {
+        if (injectedSecurityDomainsByName.containsKey(securityDomainAlias)) {
+            return null;
+        }
+        InjectedValue<SecurityDomain> securityDomainInjector = new InjectedValue<>();
+        injectedSecurityDomainsByName.put(securityDomainAlias, securityDomainInjector);
+        return securityDomainInjector;
+    }
+}

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -21,6 +21,9 @@ ejb3.default-missing-method-permissions-deny-access=If this is set to true then 
 ejb3.disable-default-ejb-permissions=This deprecated attribute has no effect and will be removed in a future release; it may never be set to a "false" value
 ejb3.disable-default-ejb-permissions.deprecated=Adding default permissions to EJB deployments is no longer supported and this configuration attribute will be removed in a future release
 ejb3.log-system-exceptions=If this is true then all EJB system (not application) exceptions will be logged. The EJB spec mandates this behaviour, however it is not recommended as it will often result in exceptions being logged twice (once by the EJB and once by the calling code)
+ejb3.security-domains=The list of security domains required by the EJB3 subsystem
+ejb3.security-domains.name=A reference to an individual security domain
+ejb3.security-domains.alias=An alias for the security domain
 
 service=Centrally configurable services that are part of the EJB3 subsystem.
 

--- a/ejb3/src/main/resources/schema/wildfly-ejb3_5_0.xsd
+++ b/ejb3/src/main/resources/schema/wildfly-ejb3_5_0.xsd
@@ -57,6 +57,7 @@
                         minOccurs="0" maxOccurs="1"/>
             <xs:element name="default-distinct-name" type="default-distinct-nameType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="default-security-domain" type="default-security-domainType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="security-domains" type="securityDomainsType" minOccurs="0" maxOccurs="1" />
             <xs:element name="default-missing-method-permissions-deny-access" type="default-missing-method-permissions-deny-accessType" minOccurs="0" maxOccurs="1" />
             <xs:element name="disable-default-ejb-permissions" type="disable-default-ejb-permissionsType" minOccurs="0" maxOccurs="1" />
             <xs:element name="statistics" type="statisticsType" minOccurs="0" maxOccurs="1"/>
@@ -399,6 +400,38 @@
 
     <xs:complexType name="statisticsType">
         <xs:attribute name="enabled" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="securityDomainsType">
+        <xs:sequence>
+            <xs:element name="security-domain" type="securityDomainRefType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="default" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    The default Elytron security domain that will be used for EJBs in the absence of any explicitly configured
+                    security domain name for the bean.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="securityDomainRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to an Elytron security domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="alias" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines an alias for this Elytron security domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="channel-creation-optionsType">

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/TransformersTestCase.java
@@ -176,7 +176,8 @@ public class TransformersTestCase extends AbstractSubsystemBaseTest {
             FailedOperationTransformationConfig.ChainedConfig chainedConfig = FailedOperationTransformationConfig.ChainedConfig.createBuilder(
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
                     .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(
-                            EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS))
+                            EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS,
+                            EJB3SubsystemRootResourceDefinition.SECURITY_DOMAINS))
                     .addConfig(new CorrectFalseToTrue(EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS))
                     .build();
 
@@ -218,7 +219,8 @@ public class TransformersTestCase extends AbstractSubsystemBaseTest {
             FailedOperationTransformationConfig.ChainedConfig chainedConfig = FailedOperationTransformationConfig.ChainedConfig.createBuilder(
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
                     .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(
-                            EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS))
+                            EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS,
+                            EJB3SubsystemRootResourceDefinition.SECURITY_DOMAINS))
                     .addConfig(new CorrectFalseToTrue(EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS))
                     .build();
 

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform-reject.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform-reject.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:ejb3:4.0">
+<subsystem xmlns="urn:jboss:domain:ejb3:5.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
@@ -76,7 +76,10 @@
     <!-- Disable pass-by-value for in-vm remote interface invocations on EJBs -->
     <in-vm-remote-interface-invocation pass-by-value="false"/>
     <default-distinct-name value="myname"/>
-    <default-security-domain value="domain"/>
+    <!-- should be rejected -->
+    <security-domains default="domain">
+        <security-domain name="domain"/>
+    </security-domains>
     <default-missing-method-permissions-deny-access value="true" />
     <disable-default-ejb-permissions value="true"/>
     <statistics enabled="${ejb.enable-statistics:true}" />

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:ejb3:4.0">
+<subsystem xmlns="urn:jboss:domain:ejb3:5.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>


### PR DESCRIPTION
Allow the EJB subsystem to declare which Elytron security domains it uses.

Sample configuration:

``` xml
<subsystem xmlns="urn:jboss:domain:ejb3:5.0">
    ...
    <security-domains default="ApplicationDomain">
        <security-domain name="ApplicationDomain" alias="MyDomain"/>
        <security-domain name="ManagementDomain"/>
    </security-domains>
    ...
</subsystem>
```

https://issues.jboss.org/browse/WFLY-5689
