### PR TITLE
[WFLY-4872] Remove the dependency on org.jboss.threads from the Elytron subsystem module since it's no longer needed

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -38,7 +38,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.threads"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron"/>
     </dependencies>


### PR DESCRIPTION
This should be the last change related to ELY-558 :)
