### PR TITLE
Temporarily ignore tests in MDBTestCases

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
@@ -43,6 +43,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -142,6 +143,7 @@ public class MDBTestCase {
      * Test a deployment descriptor based MDB
      * @throws Exception
      */
+    @Ignore("WFLY-7303")
     @Test
     public void testSuspendResumeWithMDB() throws Exception {
         boolean resumed = false;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
@@ -64,6 +64,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,6 +75,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({MDBTestCase.JmsQueueSetup.class})
+@Ignore("WFLY-7303")
 public class MDBTestCase {
 
     private static final Logger logger = Logger.getLogger(MDBTestCase.class);


### PR DESCRIPTION
When tests in org.jboss.as.test.integration.ejb.mdb.MDBTestCase and org.jboss.as.test.integration.ejb.mdb.deliveryactive.MDBTestCase fail, the tests that get run after these ones fail as well. These tests in MDBTestCases will be fixed during Phase III Remoting 5 integration but temporarily ignoring them for now will hopefully get the CI job in better shape.
