### PR TITLE
[WFLY-7730] Fix of application-security-domain removing

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -238,7 +238,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
         @Override
         protected ServiceName serviceName(String name) {
             RuntimeCapability<?> dynamicCapability = APPLICATION_SECURITY_DOMAIN_RUNTIME_CAPABILITY.fromBaseCapability(name);
-            return dynamicCapability.getCapabilityServiceName(HttpAuthenticationFactory.class);
+            return dynamicCapability.getCapabilityServiceName(Function.class);
         }
 
     }


### PR DESCRIPTION
Fix of:
java.lang.IllegalArgumentException: WFLYCTL0394: Capability 'org.wildfly.extension.undertow.application-security-domain.ejb3-tests' does not provide services of type 'class org.wildfly.security.auth.server.HttpAuthenticationFactory'