### PR TITLE
[WFLY-7607] Minor update to module.xml files to reference the new org.wildfly.naming-client module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -55,7 +55,7 @@
         <module name="org.picketbox"/>
         <!-- this optional dependency is required to be able to use this module from a jms-bridge to connect to a remote
              WildFly server [AS7-6549] -->
-        <module name="org.jboss.remote-naming" optional="true"/>
+        <module name="org.wildfly.naming-client" optional="true"/>
         <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
         <module name="sun.jdk"/>
         <!-- supported protocols (in addition to the CORE protocol) -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.jts"/>
         <module name="org.jboss.logging"/>
         <!-- allow to create a RA that connects to a remote Artemis server -->
-        <module name="org.jboss.remote-naming" optional="true"/>
+        <module name="org.wildfly.naming-client" optional="true"/>
         <module name="org.jgroups"/>
         <module name="org.wildfly.extension.messaging-activemq" services="import"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -58,6 +58,6 @@
         <module name="org.jboss.vfs"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.jboss.remote-naming"/>
+        <module name="org.wildfly.naming-client"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -70,7 +70,7 @@
         <module name="org.jboss.jts"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.jboss.remote-naming"/>
+        <module name="org.wildfly.naming-client"/>
         <module name="org.jboss.threads"/>
         <module name="org.jgroups" optional="true"/>
         <module name="org.jboss.weld.api" />

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.remote-naming"/>
+        <module name="org.wildfly.naming-client"/>
         <module name="org.jboss.remoting"/>
         <module name="org.jboss.threads"/>
         <module name="sun.jdk" />


### PR DESCRIPTION
The org.jboss.remote-naming module is now just an alias for the org.wildfly.naming-client module so updating the module.xml files to reference the new module instead.