### PR TITLE
[WFLY-7730] Fix of undertow/application-security-domain removing

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -238,7 +238,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
         @Override
         protected ServiceName serviceName(String name) {
             RuntimeCapability<?> dynamicCapability = APPLICATION_SECURITY_DOMAIN_RUNTIME_CAPABILITY.fromBaseCapability(name);
-            return dynamicCapability.getCapabilityServiceName(HttpAuthenticationFactory.class);
+            return dynamicCapability.getCapabilityServiceName(Function.class);
         }
 
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7730

Twin of https://github.com/wildfly/wildfly/pull/9451 (for upstream master) - maybe only one of them should be merged.