### PR TITLE
[WFLY-5403] Remove the temporary changes that were made to tests to explicitly specify the Context.INITIAL_CONTEXT_FACTORY and Context.PROVIDER_URL properties

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EJBUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EJBUtil.java
@@ -52,10 +52,9 @@ class EJBUtil {
      * @throws NamingException
      */
     @SuppressWarnings("unchecked")
-    public static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface, String host) throws NamingException {
+    public static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface) throws NamingException {
         final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
-        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
-        jndiProperties.put(Context.PROVIDER_URL, "remote+http://"+host+":"+8080);
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
         final Context context = new InitialContext(jndiProperties);
 
         return (T) context.lookup("ejb:/" + APPLICATION_NAME + "/" + beanImplClass.getSimpleName() + "!"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -30,9 +30,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-//import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
@@ -66,27 +64,27 @@ public class RemoteIdentityTestCase {
 
     @Test
     public void testDirect() throws Exception {
-        final SecurityInformation targetBean = EJBUtil.lookupEJB(SecuredBean.class, SecurityInformation.class, Utils.getHost(mgmtClient));
+        final SecurityInformation targetBean = EJBUtil.lookupEJB(SecuredBean.class, SecurityInformation.class);
 
         assertEquals("guest", targetBean.getPrincipalName());
     }
 
     @Test
     public void testUnsecured() throws Exception {
-        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class, Utils.getHost(mgmtClient));
+        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
         assertEquals("anonymous", targetBean.getPrincipalName());
     }
 
     @Test
     public void testSwitched() throws Exception {
-        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class, Utils.getHost(mgmtClient));
+        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 
         assertEquals("user1", targetBean.getPrincipalName("user1", "password1"));
     }
 
     @Test
     public void testNotSwitched() throws Exception {
-        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class, Utils.getHost(mgmtClient));
+        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 
         assertEquals("guest", targetBean.getPrincipalName(null, null));
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -34,7 +34,6 @@ import javax.jms.QueueSession;
 import javax.jms.Session;
 import javax.jms.TemporaryQueue;
 import javax.jms.TextMessage;
-import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
@@ -65,8 +64,6 @@ import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.Hashtable;
 
 /**
  * The Bean Provider can invoke the getCallerPrincipal and isCallerInRole methods only
@@ -99,6 +96,9 @@ public class GetCallerPrincipalTestCase {
 
     @ArquillianResource
     Deployer deployer;
+
+    @ArquillianResource
+    private InitialContext initialContext;
 
     static class JmsQueueSetup extends AbstractMgmtServerSetupTask {
 
@@ -182,7 +182,7 @@ public class GetCallerPrincipalTestCase {
     }
 
     private ITestResultsSingleton getResultsSingleton() throws NamingException {
-        return (ITestResultsSingleton) getInitialContext().lookup("ejb:/single//" + TestResultsSingleton.class.getSimpleName() + "!" + ITestResultsSingleton.class.getName());
+        return (ITestResultsSingleton) initialContext.lookup("ejb:/single//" + TestResultsSingleton.class.getSimpleName() + "!" + ITestResultsSingleton.class.getName());
     }
 
     private SecurityClient login() throws Exception {
@@ -198,7 +198,7 @@ public class GetCallerPrincipalTestCase {
         SecurityClient client = this.login();
         try {
             ITestResultsSingleton results = this.getResultsSingleton();
-            IBeanLifecycleCallback bean = (IBeanLifecycleCallback) getInitialContext().lookup("ejb:/slsb//" + SLSBLifecycleCallback.class.getSimpleName() + "!" + IBeanLifecycleCallback.class.getName());
+            IBeanLifecycleCallback bean = (IBeanLifecycleCallback) initialContext.lookup("ejb:/slsb//" + SLSBLifecycleCallback.class.getSimpleName() + "!" + IBeanLifecycleCallback.class.getName());
             log.trace("Stateless bean returns: " + bean.get());
 
             Assert.assertEquals(OK + "start", results.getSlsb("postconstruct"));
@@ -217,7 +217,7 @@ public class GetCallerPrincipalTestCase {
         SecurityClient client = this.login();
         ITestResultsSingleton results = this.getResultsSingleton();
         try {
-            IBeanLifecycleCallback bean = (IBeanLifecycleCallback) getInitialContext().lookup("ejb:/sfsb//" + SFSBLifecycleCallback.class.getSimpleName() + "!" + IBeanLifecycleCallback.class.getName() + "?stateful");
+            IBeanLifecycleCallback bean = (IBeanLifecycleCallback) initialContext.lookup("ejb:/sfsb//" + SFSBLifecycleCallback.class.getSimpleName() + "!" + IBeanLifecycleCallback.class.getName() + "?stateful");
             log.trace("Stateful bean returns: " + bean.get());
 
             Assert.assertEquals(ANONYMOUS + "start", results.getSfsb("postconstruct"));
@@ -289,14 +289,6 @@ public class GetCallerPrincipalTestCase {
             }
             client.logout();
         }
-    }
-
-    private InitialContext getInitialContext() throws NamingException {
-        final Hashtable props = new Hashtable();
-        props.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
-        //TODO Elytron - ejb-client4 integration configurable host
-        props.put(Context.PROVIDER_URL, "remote+http://" + "localhost"+ ":" + 8080);
-        return new InitialContext(props);
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -47,7 +47,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.common.DefaultConfiguration;
-import org.wildfly.naming.client.WildFlyInitialContextFactory;
 import org.wildfly.naming.java.permission.JndiPermission;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
@@ -82,7 +81,7 @@ public class RemoteNamingEjbTestCase {
 
     public InitialContext getRemoteContext() throws Exception {
         final Properties env = new Properties();
-        env.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
+        env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         env.put(Context.PROVIDER_URL, managementClient.getRemoteEjbURL().toString());
         env.put("jboss.naming.client.ejb.context", true);
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");


### PR DESCRIPTION
As part of the [changes](https://github.com/wildfly-security-incubator/wildfly/pull/44/commits/1df3c7aeac1a6b3d223237dbc759cc8f4328070f) for WFLY-5403, some tests were temporarily modified to explicitly specify the Context.INITIAL_CONTEXT_FACTORY and Context.PROVIDER_URL properties. This is no longer required since we're now able to handle the case where the Context.URL_PKG_PREFIXES property is set to "org.jboss.ejb.client.naming".