### PR TITLE
[WFLY-5403] Ensure result.complete() is called from LocalEjbReceiver.discover()

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
@@ -417,12 +417,16 @@ public class LocalEjbReceiver extends EJBReceiver implements DiscoveryProvider {
 
     @Override
     public DiscoveryRequest discover(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult result) {
-        for (final ServiceURL url : accessibleModules.values()) {
-            if (url.satisfies(filterSpec)) {
-                final URI uri = url.getLocationURI();
-                result.addMatch(uri);
+        try {
+            for (final ServiceURL url : accessibleModules.values()) {
+                if (url.satisfies(filterSpec)) {
+                    final URI uri = url.getLocationURI();
+                    result.addMatch(uri);
+                }
             }
+            return DiscoveryRequest.NULL;
+        } finally {
+            result.complete();
         }
-        return DiscoveryRequest.NULL;
     }
 }


### PR DESCRIPTION
This will fix some hangs in the basic integration tests.