### PR TITLE
Adapt tests to the new EJB client API

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
@@ -56,8 +56,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ContainerInterceptorsTestCase {
 
-    private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
-
     private static final String EJB_JAR_NAME = "ejb-container-interceptors";
 
     @ArquillianResource
@@ -169,42 +167,41 @@ bean = InitialContext.doLookup("java:module/" + FlowTrackingBean.class
     // force real remote invocation so that the RemotingConnectionEJBReceiver is used instead of a LocalEJBReceiver
     @RunAsClient
     public void testDataPassingForContainerInterceptorsOnRemoteView() throws Exception {
-        // get hold of the EJBClientContext
-        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
-
         // create some data that the client side interceptor will pass along during the EJB invocation
         final Map<String, Object> interceptorData = new HashMap<String, Object>();
         interceptorData.put(FlowTrackingBean.CONTEXT_DATA_KEY, ContainerInterceptorOne.class.getName());
         final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
-        // register the client side interceptor
-        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
+        // get hold of the EJBClientContext and register the client side interceptor
+        EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(clientInterceptor);
 
         final Hashtable<String, Object> jndiProps = new Hashtable<String, Object>();
         jndiProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
         final Context jndiCtx = new InitialContext(jndiProps);
-        final FlowTracker bean = (FlowTracker) jndiCtx.lookup("ejb:/" + EJB_JAR_NAME + "/"
-                + FlowTrackingBean.class.getSimpleName() + "!" + FlowTracker.class.getName());
-        final String message = "foo";
-        // we passed ContainerInterceptorOne as the value of the context data for the invocation, which means that we want the ContainerInterceptorOne
-        // to be skipped, so except that interceptor, the rest should be invoked.
-        final String expectedResultForFirstInvocation = NonContainerInterceptor.class.getName() + " "
-                + FlowTrackingBean.class.getName() + " " + message;
-        final String firstResult = bean.echo(message);
-        Assert.assertEquals("Unexpected result invoking on bean when passing context data via EJB client interceptor",
-                expectedResultForFirstInvocation, firstResult);
+        ejbClientContext.runCallable(() -> {
+            final FlowTracker bean = (FlowTracker) jndiCtx.lookup("ejb:/" + EJB_JAR_NAME + "/"
+                    + FlowTrackingBean.class.getSimpleName() + "!" + FlowTracker.class.getName());
+            final String message = "foo";
+            // we passed ContainerInterceptorOne as the value of the context data for the invocation, which means that we want the ContainerInterceptorOne
+            // to be skipped, so except that interceptor, the rest should be invoked.
+            final String expectedResultForFirstInvocation = NonContainerInterceptor.class.getName() + " "
+                    + FlowTrackingBean.class.getName() + " " + message;
+            final String firstResult = bean.echo(message);
+            Assert.assertEquals("Unexpected result invoking on bean when passing context data via EJB client interceptor",
+                    expectedResultForFirstInvocation, firstResult);
 
-        // Now try another invocation, this time skip a different interceptor
-        interceptorData.clear();
-        interceptorData.put(FlowTrackingBean.CONTEXT_DATA_KEY, NonContainerInterceptor.class.getName());
-        final String secondMessage = "bar";
-        // we passed NonContainerInterceptor as the value of the context data for the invocation, which means that we want the NonContainerInterceptor
-        // to be skipped, so except that interceptor, the rest should be invoked.
-        final String expectedResultForSecondInvocation = ContainerInterceptorOne.class.getName() + " "
-                + FlowTrackingBean.class.getName() + " " + secondMessage;
-        final String secondResult = bean.echo(secondMessage);
-        Assert.assertEquals("Unexpected result invoking on bean when passing context data via EJB client interceptor",
-                expectedResultForSecondInvocation, secondResult);
-
+            // Now try another invocation, this time skip a different interceptor
+            interceptorData.clear();
+            interceptorData.put(FlowTrackingBean.CONTEXT_DATA_KEY, NonContainerInterceptor.class.getName());
+            final String secondMessage = "bar";
+            // we passed NonContainerInterceptor as the value of the context data for the invocation, which means that we want the NonContainerInterceptor
+            // to be skipped, so except that interceptor, the rest should be invoked.
+            final String expectedResultForSecondInvocation = ContainerInterceptorOne.class.getName() + " "
+                    + FlowTrackingBean.class.getName() + " " + secondMessage;
+            final String secondResult = bean.echo(secondMessage);
+            Assert.assertEquals("Unexpected result invoking on bean when passing context data via EJB client interceptor",
+                    expectedResultForSecondInvocation, secondResult);
+            return null;
+        });
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
@@ -54,7 +54,6 @@ import org.junit.runner.RunWith;
  * @author Jaikiran Pai
  */
 @RunWith(Arquillian.class)
-//TODO Elytron - ejb-client4 integration
 public class ContainerInterceptorsTestCase {
 
     private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
@@ -177,6 +176,8 @@ bean = InitialContext.doLookup("java:module/" + FlowTrackingBean.class
         final Map<String, Object> interceptorData = new HashMap<String, Object>();
         interceptorData.put(FlowTrackingBean.CONTEXT_DATA_KEY, ContainerInterceptorOne.class.getName());
         final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
+        // register the client side interceptor
+        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
 
         final Hashtable<String, Object> jndiProps = new Hashtable<String, Object>();
         jndiProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
@@ -71,6 +71,12 @@ import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientInterceptor.Registration;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.security.ClientLoginModule;
@@ -93,7 +99,6 @@ import org.junit.runner.RunWith;
         SwitchIdentityTestCase.SecurityRealmsSetup.class, //
         SwitchIdentityTestCase.RemotingSetup.class })
 @RunAsClient
-//TODO Elytron ejb-client 4 integration
 public class SwitchIdentityTestCase {
 
     private static final String EJB_OUTBOUND_SOCKET_BINDING = "ejb-outbound";
@@ -195,6 +200,10 @@ public class SwitchIdentityTestCase {
                     CLIENT_LOGIN_CONFIG);
             loginContext.login();
 
+            // register the client side interceptor
+            final Registration clientInterceptorHandler = EJBClientContext.requireCurrent().registerInterceptor(112567,
+                    new ClientSecurityInterceptor());
+
             final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
             final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
 
@@ -207,6 +216,8 @@ public class SwitchIdentityTestCase {
             testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
             testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
             testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
+
+            clientInterceptorHandler.remove();
         } finally {
             if (loginContext != null) {
                 loginContext.logout();
@@ -219,6 +230,13 @@ public class SwitchIdentityTestCase {
      */
     private void callUsingSecurityContextAssociation(String userName, boolean hasRole1, boolean hasRole2) throws Exception {
         try {
+            final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+            EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+            final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+            EJBClientContext.setSelector(selector);
+            // register the client side interceptor
+            final Registration clientInterceptorHandler = EJBClientContext.requireCurrent().registerInterceptor(112567,
+                    new ClientSecurityInterceptor());
             SecurityContextAssociation.setPrincipal(new SimplePrincipal(userName));
 
             final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
@@ -234,6 +252,7 @@ public class SwitchIdentityTestCase {
             testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
             testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
 
+            clientInterceptorHandler.remove();
         } finally {
             SecurityContextAssociation.clearSecurityContext();
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
@@ -71,12 +71,7 @@ import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.EJBClientInterceptor.Registration;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.security.ClientLoginModule;
@@ -230,9 +225,9 @@ public class SwitchIdentityTestCase {
     private void callUsingSecurityContextAssociation(String userName, boolean hasRole1, boolean hasRole2) throws Exception {
         try {
             final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
-            EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
-            final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
-            EJBClientContext.setSelector(selector);
+            // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+            // that should be used for this test using ejbClientConfiguration
+
             // register the client side interceptor
             final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(new ClientSecurityInterceptor());
             SecurityContextAssociation.setPrincipal(new SimplePrincipal(userName));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
@@ -201,23 +201,22 @@ public class SwitchIdentityTestCase {
             loginContext.login();
 
             // register the client side interceptor
-            final Registration clientInterceptorHandler = EJBClientContext.requireCurrent().registerInterceptor(112567,
-                    new ClientSecurityInterceptor());
+            final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(new ClientSecurityInterceptor());
+            ejbClientContext.runCallable(() -> {
+                final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
+                final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
 
-            final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
-            final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
+                //test direct access
+                testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
 
-            //test direct access
-            testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
-
-            //test security context propagation
-            testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
-
-            clientInterceptorHandler.remove();
+                //test security context propagation
+                testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
+                return null;
+            });
         } finally {
             if (loginContext != null) {
                 loginContext.logout();
@@ -235,24 +234,24 @@ public class SwitchIdentityTestCase {
             final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
             EJBClientContext.setSelector(selector);
             // register the client side interceptor
-            final Registration clientInterceptorHandler = EJBClientContext.requireCurrent().registerInterceptor(112567,
-                    new ClientSecurityInterceptor());
+            final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(new ClientSecurityInterceptor());
             SecurityContextAssociation.setPrincipal(new SimplePrincipal(userName));
 
-            final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
-            final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
+            ejbClientContext.runCallable(() -> {
+                final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
+                final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
 
-            //test direct access
-            testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
+                //test direct access
+                testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
 
-            //test security context propagation
-            testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
-
-            clientInterceptorHandler.remove();
+                //test security context propagation
+                testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
+                return null;
+            });
         } finally {
             SecurityContextAssociation.clearSecurityContext();
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
@@ -202,23 +202,23 @@ public class SwitchIdentityTestCase {
             loginContext.login();
 
             // register the client side interceptor
-            final Registration clientInterceptorHandler = EJBClientContext.requireCurrent().registerInterceptor(112567,
-                    new ClientSecurityInterceptor());
+            final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(new ClientSecurityInterceptor());
+            ejbClientContext.runCallable(() -> {
+                final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
+                final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
 
-            final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
-            final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
+                //test direct access
+                testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
 
-            //test direct access
-            testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
+                //test security context propagation
+                testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
+                return null;
+            });
 
-            //test security context propagation
-            testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
-
-            clientInterceptorHandler.remove();
         } finally {
             if (loginContext != null) {
                 loginContext.logout();
@@ -236,24 +236,24 @@ public class SwitchIdentityTestCase {
             final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
             EJBClientContext.setSelector(selector);
             // register the client side interceptor
-            final Registration clientInterceptorHandler = EJBClientContext.requireCurrent().registerInterceptor(112567,
-                    new ClientSecurityInterceptor());
+            final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(new ClientSecurityInterceptor());
             SecurityContextAssociation.setPrincipal(new SimplePrincipal(userName));
 
-            final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
-            final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
+            ejbClientContext.runCallable(() -> {
+                final Manage targetBean = EJBUtil.lookupEJB(TargetBean.class, Manage.class);
+                final Manage bridgeBean = EJBUtil.lookupEJB(BridgeBean.class, Manage.class);
 
-            //test direct access
-            testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
+                //test direct access
+                testMethodAccess(targetBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(targetBean, ManageMethodEnum.ROLE2, hasRole2);
 
-            //test security context propagation
-            testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
-            testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
-
-            clientInterceptorHandler.remove();
+                //test security context propagation
+                testMethodAccess(bridgeBean, ManageMethodEnum.ALLROLES, true);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE1, hasRole1);
+                testMethodAccess(bridgeBean, ManageMethodEnum.ROLE2, hasRole2);
+                return null;
+            });
         } finally {
             SecurityContextAssociation.clearSecurityContext();
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
@@ -73,12 +73,7 @@ import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.EJBClientInterceptor.Registration;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.security.ClientLoginModule;
@@ -232,9 +227,9 @@ public class SwitchIdentityTestCase {
     private void callUsingSecurityContextAssociation(String userName, boolean hasRole1, boolean hasRole2) throws Exception {
         try {
             final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
-            EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
-            final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
-            EJBClientContext.setSelector(selector);
+            // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+            // that should be used for this test using ejbClientConfiguration
+
             // register the client side interceptor
             final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(new ClientSecurityInterceptor());
             SecurityContextAssociation.setPrincipal(new SimplePrincipal(userName));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
@@ -68,7 +68,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup({ MDBRAScopeCdiIntegrationTestCase.JmsQueueSetup.class })
-//TODO Elytron - ejb-client4 integration
 public class MDBRAScopeCdiIntegrationTestCase extends ContainerResourceMgmtTestBase {
 
     public static final String testDeploymentName = "test.jar";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/EJBClientAPIUsageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/EJBClientAPIUsageTestCase.java
@@ -38,6 +38,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.ejb.client.Affinity;
 import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatefulEJBLocator;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.logging.Logger;
@@ -47,6 +48,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -81,6 +83,20 @@ public class EJBClientAPIUsageTestCase {
         ear.addAsModule(jar);
 
         return ear;
+    }
+
+
+    /**
+     * Create and setup the EJB client context backed by the remoting receiver
+     *
+     * @throws Exception
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        // set the tx context
+        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+
     }
 
     /**
@@ -194,7 +210,7 @@ public class EJBClientAPIUsageTestCase {
             "Need to think if there's a different way to test this. Else just remove this test")
     public void testSFSBAccessFailureWithoutSession() throws Exception {
         // create a locator without a session
-        final StatefulEJBLocator<Counter> locator = new StatefulEJBLocator<Counter>(Counter.class, APP_NAME, MODULE_NAME, CounterBean.class.getSimpleName(), "", null, Affinity.NONE);
+        final StatefulEJBLocator<Counter> locator = new StatefulEJBLocator<Counter>(Counter.class, APP_NAME, MODULE_NAME, CounterBean.class.getSimpleName(), "", null, Affinity.NONE, null);
         final Counter counter = EJBClient.createProxy(locator);
         Assert.assertNotNull("Received a null proxy", counter);
         // invoke the bean without creating a session

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/EJBClientAPIUsageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/EJBClientAPIUsageTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.ejb.client.Affinity;
 import org.jboss.ejb.client.EJBClient;
-import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatefulEJBLocator;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.logging.Logger;
@@ -93,9 +92,10 @@ public class EJBClientAPIUsageTestCase {
      */
     @Before
     public void beforeTest() throws Exception {
-        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        // TODO Elytron: Determine how this should be adapted once the transaction client changes are in
+        //final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
         // set the tx context
-        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+        //EJBClientTransactionContext.setGlobalContext(localUserTxContext);
 
     }
 
@@ -210,7 +210,7 @@ public class EJBClientAPIUsageTestCase {
             "Need to think if there's a different way to test this. Else just remove this test")
     public void testSFSBAccessFailureWithoutSession() throws Exception {
         // create a locator without a session
-        final StatefulEJBLocator<Counter> locator = new StatefulEJBLocator<Counter>(Counter.class, APP_NAME, MODULE_NAME, CounterBean.class.getSimpleName(), "", null, Affinity.NONE, null);
+        final StatefulEJBLocator<Counter> locator = new StatefulEJBLocator<Counter>(Counter.class, APP_NAME, MODULE_NAME, CounterBean.class.getSimpleName(), "", null, Affinity.NONE);
         final Counter counter = EJBClient.createProxy(locator);
         Assert.assertNotNull("Received a null proxy", counter);
         // invoke the bean without creating a session

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/EJBClientInterceptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/EJBClientInterceptorTestCase.java
@@ -45,7 +45,6 @@ import org.junit.runner.RunWith;
  * @author Jaikiran Pai
  */
 @RunWith(Arquillian.class)
-//TODO Elytron - ejb-client4 integration
 public class EJBClientInterceptorTestCase {
 
     private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
@@ -80,6 +79,10 @@ public class EJBClientInterceptorTestCase {
 
         interceptorData.put(keyOne, valueOne);
         interceptorData.put(keyTwo, valueTwo);
+
+        final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
+        // register the client side interceptor
+        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
 
         final Hashtable props = new Hashtable();
         props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/EJBClientInterceptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/EJBClientInterceptorTestCase.java
@@ -47,8 +47,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class EJBClientInterceptorTestCase {
 
-    private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
-
     private static final String APP_NAME = "";
     private static final String DISTINCT_NAME = "";
     private static final String MODULE_NAME = "ejb-client-interceptor-test-module";
@@ -67,9 +65,6 @@ public class EJBClientInterceptorTestCase {
     @Test
     @RunAsClient // run as a truly remote client
     public void testEJBClientInterceptionFromRemoteClient() throws Exception {
-        // get hold of the EJBClientContext
-        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
-
         // create some data that the client side interceptor will pass along during the EJB invocation
         final Map<String, Object> interceptorData = new HashMap<String, Object>();
         final String keyOne = "foo";
@@ -81,26 +76,29 @@ public class EJBClientInterceptorTestCase {
         interceptorData.put(keyTwo, valueTwo);
 
         final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
-        // register the client side interceptor
-        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
+        // get hold of the EJBClientContext and register the client side interceptor
+        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(clientInterceptor);
 
         final Hashtable props = new Hashtable();
         props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
         final Context jndiContext = new InitialContext(props);
-        final RemoteSFSB remoteSFSB = (RemoteSFSB) jndiContext.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME
-                + "/" + SimpleSFSB.class.getSimpleName() + "!" + RemoteSFSB.class.getName() + "?stateful");
+        ejbClientContext.runCallable(() -> {
+            final RemoteSFSB remoteSFSB = (RemoteSFSB) jndiContext.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME
+                    + "/" + SimpleSFSB.class.getSimpleName() + "!" + RemoteSFSB.class.getName() + "?stateful");
 
-        // invoke the bean and ask it for the invocation data that it saw on the server side
-        final Map<String, Object> valuesSeenOnServerSide = remoteSFSB.getInvocationData(keyOne, keyTwo);
-        // make sure the server side bean was able to get the data which was passed on by the client side
-        // interceptor
-        Assert.assertNotNull("Server side context data was expected to be non-null", valuesSeenOnServerSide);
-        Assert.assertFalse("Server side context data was expected to be non-empty", valuesSeenOnServerSide.isEmpty());
-        for (final Map.Entry<String, Object> clientInterceptorDataEntry : interceptorData.entrySet()) {
-            final String key = clientInterceptorDataEntry.getKey();
-            final Object expectedValue = clientInterceptorDataEntry.getValue();
-            Assert.assertEquals("Unexpected value in bean, on server side, via InvocationContext.getContextData() for key " + key, expectedValue, valuesSeenOnServerSide.get(key));
-        }
+            // invoke the bean and ask it for the invocation data that it saw on the server side
+            final Map<String, Object> valuesSeenOnServerSide = remoteSFSB.getInvocationData(keyOne, keyTwo);
+            // make sure the server side bean was able to get the data which was passed on by the client side
+            // interceptor
+            Assert.assertNotNull("Server side context data was expected to be non-null", valuesSeenOnServerSide);
+            Assert.assertFalse("Server side context data was expected to be non-empty", valuesSeenOnServerSide.isEmpty());
+            for (final Map.Entry<String, Object> clientInterceptorDataEntry : interceptorData.entrySet()) {
+                final String key = clientInterceptorDataEntry.getKey();
+                final Object expectedValue = clientInterceptorDataEntry.getValue();
+                Assert.assertEquals("Unexpected value in bean, on server side, via InvocationContext.getContextData() for key " + key, expectedValue, valuesSeenOnServerSide.get(key));
+            }
+            return null;
+        });
 
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/RemoteViewInvokingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/RemoteViewInvokingBean.java
@@ -42,12 +42,10 @@ public class RemoteViewInvokingBean implements RemoteViewInvoker {
     private RemoteSFSB remoteViewSFSB;
 
     private Map<String, Object> interceptorData;
+    private EJBClientContext ejbClientContext;
 
     @PostConstruct
     void setupClientInterceptor() {
-        // get hold of the EJBClientContext
-        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
-
         // create some data that the client side interceptor will pass along during the EJB invocation
         this.interceptorData = new HashMap<String, Object>();
         final String keyOne = "abc";
@@ -59,13 +57,17 @@ public class RemoteViewInvokingBean implements RemoteViewInvoker {
         interceptorData.put(keyTwo, valueTwo);
 
         final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
-        // register the client side interceptor
-        ejbClientContext.registerInterceptor(111112, clientInterceptor);
+        // get hold of the EJBClientContext and register the client side interceptor
+        ejbClientContext = EJBClientContext.requireCurrent().withAddedInterceptors(clientInterceptor);
     }
 
     @Override
     public Map<String, Object> invokeRemoteViewAndGetInvocationData(final String... key) {
-        return remoteViewSFSB.getInvocationData(key);
+        try {
+            return ejbClientContext.runCallable(() -> remoteViewSFSB.getInvocationData(key));
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/RemoteViewInvokingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/interceptor/RemoteViewInvokingBean.java
@@ -36,7 +36,6 @@ import java.util.Map;
  */
 @Stateful(passivationCapable = false)
 @Remote(RemoteViewInvoker.class)
-//TODO Elytron - ejb-client4 integration
 public class RemoteViewInvokingBean implements RemoteViewInvoker {
 
     @EJB
@@ -58,6 +57,10 @@ public class RemoteViewInvokingBean implements RemoteViewInvoker {
 
         interceptorData.put(keyOne, valueOne);
         interceptorData.put(keyTwo, valueTwo);
+
+        final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
+        // register the client side interceptor
+        ejbClientContext.registerInterceptor(111112, clientInterceptor);
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientUserTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientUserTransactionTestCase.java
@@ -29,6 +29,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.ejb.remote.common.EJBManagementUtil;
 import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -36,6 +37,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +47,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client4
 public class EJBClientUserTransactionTestCase {
     private static final Logger logger = Logger.getLogger(EJBClientUserTransactionTestCase.class);
 
@@ -109,6 +110,19 @@ public class EJBClientUserTransactionTestCase {
         final UserTransaction userTransaction = EJBClient.getUserTransaction(nodeName);
         userTransaction.begin();
         userTransaction.rollback();
+    }
+
+    /**
+     * Create and setup the EJB client context backed by the remoting receiver
+     *
+     * @throws Exception
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        // set the tx context
+        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientUserTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientUserTransactionTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.ejb.remote.common.EJBManagementUtil;
 import org.jboss.ejb.client.EJBClient;
-import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -119,9 +118,10 @@ public class EJBClientUserTransactionTestCase {
      */
     @Before
     public void beforeTest() throws Exception {
-        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        // TODO Elytron: Determine how this should be adapted once the transaction client changes are in
+        //final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
         // set the tx context
-        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+        //EJBClientTransactionContext.setGlobalContext(localUserTxContext);
 
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -39,6 +40,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +50,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client4 integration
 public class EJBClientXidTransactionTestCase {
 
     private static final Logger logger = Logger.getLogger(EJBClientXidTransactionTestCase.class);
@@ -89,6 +90,19 @@ public class EJBClientXidTransactionTestCase {
     public static void beforeTestClass() throws Exception {
         // setup the tx manager and tx sync registry
         instantiateTxManagement();
+    }
+
+    /**
+     * Create and setup the EJB client context backed by the remoting receiver
+     *
+     * @throws Exception
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        // create a client side tx context
+        final EJBClientTransactionContext txContext = EJBClientTransactionContext.create(txManager, txSyncRegistry);
+        // associate the tx context
+        EJBClientTransactionContext.setGlobalContext(txContext);
     }
 
     private static void instantiateTxManagement() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.ejb.client.EJBClient;
-import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -99,10 +98,11 @@ public class EJBClientXidTransactionTestCase {
      */
     @Before
     public void beforeTest() throws Exception {
+        // TODO Elytron: Determine how this should be adapted once the transaction client changes are in
         // create a client side tx context
-        final EJBClientTransactionContext txContext = EJBClientTransactionContext.create(txManager, txSyncRegistry);
+        //final EJBClientTransactionContext txContext = EJBClientTransactionContext.create(txManager, txSyncRegistry);
         // associate the tx context
-        EJBClientTransactionContext.setGlobalContext(txContext);
+        //EJBClientTransactionContext.setGlobalContext(txContext);
     }
 
     private static void instantiateTxManagement() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EJBUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EJBUtil.java
@@ -55,6 +55,7 @@ class EJBUtil {
     public static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface) throws NamingException {
         final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
         jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        //        jndiProperties.put("jboss.naming.client.ejb.context", "true");
         final Context context = new InitialContext(jndiProperties);
 
         return (T) context.lookup("ejb:/" + APPLICATION_NAME + "/" + beanImplClass.getSimpleName() + "!"
@@ -63,7 +64,7 @@ class EJBUtil {
 
     /**
      * Creates {@link Properties} for the EJB client configuration.
-     * <p>
+     *
      * <pre>
      * remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
      *

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -33,11 +33,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientConfiguration;
-import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
@@ -71,9 +66,8 @@ public class RemoteIdentityTestCase {
     @Test
     public void testDirect() throws Exception {
         final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
-        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
-        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
-        EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using ejbClientConfiguration
 
         final SecurityInformation targetBean = EJBUtil.lookupEJB(SecuredBean.class, SecurityInformation.class);
 
@@ -83,9 +77,8 @@ public class RemoteIdentityTestCase {
     @Test
     public void testUnsecured() throws Exception {
         final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
-        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
-        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
-        EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using ejbClientConfiguration
 
         final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 
@@ -95,9 +88,8 @@ public class RemoteIdentityTestCase {
     @Test
     public void testSwitched() throws Exception {
         final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
-        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
-        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
-        EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using ejbClientConfiguration
 
         final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 
@@ -107,9 +99,8 @@ public class RemoteIdentityTestCase {
     @Test
     public void testNotSwitched() throws Exception {
         final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
-        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
-        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
-        EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using ejbClientConfiguration
 
         final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -24,13 +24,20 @@ package org.jboss.as.test.integration.ejb.remote.security;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
@@ -43,7 +50,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client4 integration: this test requires introduction of many chains of authentication based on used protocol
 public class RemoteIdentityTestCase {
 
     @ArquillianResource
@@ -64,6 +70,11 @@ public class RemoteIdentityTestCase {
 
     @Test
     public void testDirect() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
         final SecurityInformation targetBean = EJBUtil.lookupEJB(SecuredBean.class, SecurityInformation.class);
 
         assertEquals("guest", targetBean.getPrincipalName());
@@ -71,12 +82,23 @@ public class RemoteIdentityTestCase {
 
     @Test
     public void testUnsecured() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
         final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
+
         assertEquals("anonymous", targetBean.getPrincipalName());
     }
 
     @Test
     public void testSwitched() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
         final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 
         assertEquals("user1", targetBean.getPrincipalName("user1", "password1"));
@@ -84,6 +106,11 @@ public class RemoteIdentityTestCase {
 
     @Test
     public void testNotSwitched() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
         final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
 
         assertEquals("guest", targetBean.getPrincipalName(null, null));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnSBTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnSBTest.java
@@ -24,6 +24,8 @@ package org.jboss.as.test.integration.ejb.security;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
 import javax.ejb.EJBAccessException;
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -42,19 +44,31 @@ import org.jboss.as.test.integration.ejb.security.authorization.AnnOnlyCheckSLSB
 import org.jboss.as.test.integration.ejb.security.authorization.ParentAnnOnlyCheck;
 import org.jboss.as.test.integration.ejb.security.authorization.SimpleAuthorizationRemote;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBReceiver;
+import org.jboss.ejb.client.remoting.IoFutureHelper;
+import org.jboss.ejb.client.remoting.RemotingConnectionEJBReceiver;
 import org.jboss.logging.Logger;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.Endpoint;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Sequence;
 
 /**
  * This is a common parent for test cases to check whether basic EJB authorization works from an EJB client to a remote EJB.
  *
  * @author <a href="mailto:jan.lanik@redhat.com">Jan Lanik</a>
  */
-
-//TODO Elytron - ejb-client4 integration
 public abstract class AnnSBTest {
 
     @ContainerResource
@@ -63,11 +77,11 @@ public abstract class AnnSBTest {
 
     public static Archive<JavaArchive> testAppDeployment(final Logger LOG, final String MODULE, final Class SB_TO_TEST) {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE + ".jar")
-                .addClass(SB_TO_TEST)
-                .addClass(SimpleAuthorizationRemote.class)
-                .addClass(ParentAnnOnlyCheck.class)
-                .addClass(AnnOnlyCheckSLSBForInjection.class)
-                .addClass(AnnOnlyCheckSFSBForInjection.class);
+           .addClass(SB_TO_TEST)
+           .addClass(SimpleAuthorizationRemote.class)
+           .addClass(ParentAnnOnlyCheck.class)
+           .addClass(AnnOnlyCheckSLSBForInjection.class)
+           .addClass(AnnOnlyCheckSFSBForInjection.class);
         jar.addAsManifestResource(AnnSBTest.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         jar.addPackage(CommonCriteria.class.getPackage());
         return jar;
@@ -75,12 +89,12 @@ public abstract class AnnSBTest {
 
     private SimpleAuthorizationRemote getBean(final String MODULE, final Logger log, final Class SB_CLASS, Context ctx) throws NamingException {
         String myContext = Util.createRemoteEjbJndiContext(
-                "",
-                MODULE,
-                "",
-                SB_CLASS.getSimpleName(),
-                SimpleAuthorizationRemote.class.getName(),
-                isBeanClassStatefull(SB_CLASS));
+           "",
+           MODULE,
+           "",
+           SB_CLASS.getSimpleName(),
+           SimpleAuthorizationRemote.class.getName(),
+           isBeanClassStatefull(SB_CLASS));
 
         log.trace("JNDI name=" + myContext);
 
@@ -100,37 +114,44 @@ public abstract class AnnSBTest {
      */
     public void testSingleMethodAnnotationsNoUserTemplate(final String MODULE, final Logger log, final Class SB_CLASS) throws Exception {
         final Context ctx = Util.createNamingContext();
-        String echoValue = getBean(MODULE, log, SB_CLASS, ctx).defaultAccess("alohomora");
-        Assert.assertEquals(echoValue, "alohomora");
-
+        ContextSelector<EJBClientContext> old = setupEJBClientContextSelector("$local", null);
         try {
-            echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessOne("alohomora");
-            Assert.fail("Method cannot be successfully called without logged in user");
-        } catch (Exception e) {
-            // expected
-            Assert.assertTrue("Thrown exception must be EJBAccessException, but was " + e.getClass().getSimpleName(), e instanceof EJBAccessException);
-        }
 
-        try {
-            echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessMore("alohomora");
-            Assert.fail("Method cannot be successfully called without logged in user");
-        } catch (EJBAccessException e) {
-            // expected
-        }
-
-        try {
-            echoValue = getBean(MODULE, log, SB_CLASS, ctx).permitAll("alohomora");
+            String echoValue = getBean(MODULE, log, SB_CLASS, ctx).defaultAccess("alohomora");
             Assert.assertEquals(echoValue, "alohomora");
-        } catch (Exception e) {
-            Assert.fail("@PermitAll annotation must allow all users and no users to call the method");
-        }
 
-        try {
-            echoValue = getBean(MODULE, log, SB_CLASS, ctx).denyAll("alohomora");
-            Assert.fail("@DenyAll annotation must allow all users and no users to call the method");
-        } catch (Exception e) {
-            // expected
-            Assert.assertTrue("Thrown exception must be EJBAccessException, but was " + e.getClass().getSimpleName(), e instanceof EJBAccessException);
+            try {
+                echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessOne("alohomora");
+                Assert.fail("Method cannot be successfully called without logged in user");
+            } catch (Exception e) {
+                // expected
+                Assert.assertTrue("Thrown exception must be EJBAccessException, but was " + e.getClass().getSimpleName(), e instanceof EJBAccessException);
+            }
+
+            try {
+                echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessMore("alohomora");
+                Assert.fail("Method cannot be successfully called without logged in user");
+            } catch (EJBAccessException e) {
+                // expected
+            }
+
+            try {
+                echoValue = getBean(MODULE, log, SB_CLASS, ctx).permitAll("alohomora");
+                Assert.assertEquals(echoValue, "alohomora");
+            } catch (Exception e) {
+                Assert.fail("@PermitAll annotation must allow all users and no users to call the method");
+            }
+
+            try {
+                echoValue = getBean(MODULE, log, SB_CLASS, ctx).denyAll("alohomora");
+                Assert.fail("@DenyAll annotation must allow all users and no users to call the method");
+            } catch (Exception e) {
+                // expected
+                Assert.assertTrue("Thrown exception must be EJBAccessException, but was " + e.getClass().getSimpleName(), e instanceof EJBAccessException);
+            }
+
+        } finally {
+            safeClose((Closeable) EJBClientContext.setSelector(old));
         }
     }
 
@@ -148,7 +169,7 @@ public abstract class AnnSBTest {
      */
     public void testSingleMethodAnnotationsUser1Template(final String MODULE, final Logger log, final Class SB_CLASS) throws Exception {
         final Context ctx = Util.createNamingContext();
-        //ContextSelector<EJBClientContext> old = setupEJBClientContextSelector("user1", "password1");
+        ContextSelector<EJBClientContext> old = setupEJBClientContextSelector("user1", "password1");
         try {
 
             try {
@@ -198,7 +219,7 @@ public abstract class AnnSBTest {
             }
 
         } finally {
-            //safeClose((Closeable) EJBClientContext.setSelector(old));
+            safeClose((Closeable) EJBClientContext.setSelector(old));
         }
     }
 
@@ -216,41 +237,106 @@ public abstract class AnnSBTest {
      */
     public void testSingleMethodAnnotationsUser2Template(final String MODULE, final Logger log, final Class SB_CLASS) throws Exception {
         final Context ctx = Util.createNamingContext();
+        ContextSelector<EJBClientContext> old = setupEJBClientContextSelector("user2", "password2");
         try {
-            String echoValue = getBean(MODULE, log, SB_CLASS, ctx).defaultAccess("alohomora");
-            Assert.assertEquals(echoValue, "alohomora");
-        } catch (EJBAccessException e) {
-            Assert.fail("EJBAccessException not expected");
+
+            try {
+                String echoValue = getBean(MODULE, log, SB_CLASS, ctx).defaultAccess("alohomora");
+                Assert.assertEquals(echoValue, "alohomora");
+            } catch (EJBAccessException e) {
+                Assert.fail("EJBAccessException not expected");
+            }
+
+            try {
+                String echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessOne("alohomora");
+                Assert.fail("Method cannot be successfully called with logged in user2");
+            } catch (Exception e) {
+                // expected
+                Assert.assertTrue("Thrown exception must be EJBAccessException, but was different", e instanceof EJBAccessException);
+            }
+
+
+            try {
+                String echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessMore("alohomora");
+                Assert.assertEquals(echoValue, "alohomora");
+            } catch (EJBAccessException e) {
+                Assert.fail("EJBAccessException not expected");
+            }
+
+            try {
+                String echoValue = getBean(MODULE, log, SB_CLASS, ctx).permitAll("alohomora");
+                Assert.assertEquals(echoValue, "alohomora");
+            } catch (Exception e) {
+                Assert.fail("@PermitAll annotation must allow all users and no users to call the method - principal.");
+            }
+
+            try {
+                String echoValue = getBean(MODULE, log, SB_CLASS, ctx).denyAll("alohomora");
+                Assert.fail("@DenyAll annotation must allow all users and no users to call the method");
+            } catch (Exception e) {
+                // expected
+                Assert.assertTrue("Thrown exception must be EJBAccessException, but was different", e instanceof EJBAccessException);
+            }
+        } finally {
+            safeClose((Closeable) EJBClientContext.setSelector(old));
         }
 
-        try {
-            String echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessOne("alohomora");
-            Assert.fail("Method cannot be successfully called with logged in user2");
-        } catch (Exception e) {
-            // expected
-            Assert.assertTrue("Thrown exception must be EJBAccessException, but was different", e instanceof EJBAccessException);
+    }
+
+
+    protected ContextSelector<EJBClientContext> setupEJBClientContextSelector(String username, String password) throws IOException {
+        // create the endpoint
+        final Endpoint endpoint = Endpoint.getCurrent();
+        final URI connectionURI = managementClient.getRemoteEjbURL();
+
+        OptionMap.Builder builder = OptionMap.builder().set(Options.SASL_POLICY_NOANONYMOUS, true);
+        builder.set(Options.SASL_POLICY_NOPLAINTEXT, false);
+        if (password != null) {
+            builder.set(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of("JBOSS-LOCAL-USER"));
+        } else {
+            builder.set(Options.SASL_MECHANISMS, Sequence.of("JBOSS-LOCAL-USER"));
         }
 
-        try {
-            String echoValue = getBean(MODULE, log, SB_CLASS, ctx).roleBasedAccessMore("alohomora");
-            Assert.assertEquals(echoValue, "alohomora");
-        } catch (EJBAccessException e) {
-            Assert.fail("EJBAccessException not expected");
+        final AuthenticationContext authenticationContext = AuthenticationContext.empty()
+                .with(
+                        MatchRule.ALL,
+                        AuthenticationConfiguration.EMPTY
+                                .useCallbackHandler(new AuthenticationCallbackHandler(username, password))
+                                .allowSaslMechanisms("JBOSS-LOCAL-USER", "DIGEST-MD5")
+                                .useProvidersFromClassLoader(AnnSBTest.class.getClassLoader()));
+        final IoFuture<Connection> futureConnection = endpoint.connect(connectionURI, builder.getMap(), authenticationContext);
+        // wait for the connection to be established
+        final Connection connection = IoFutureHelper.get(futureConnection, 5000, TimeUnit.MILLISECONDS);
+        // create a remoting EJB receiver for this connection
+        final EJBReceiver receiver = new RemotingConnectionEJBReceiver(connection);
+        // associate it with the client context
+        EJBClientContext context = EJBClientContext.create();
+        context.registerEJBReceiver(receiver);
+        return EJBClientContext.setSelector(new ClosableContextSelector(context, endpoint, connection, receiver));
+    }
+
+    private class ClosableContextSelector implements ContextSelector<EJBClientContext>, Closeable {
+        private EJBClientContext context;
+        private Endpoint endpoint;
+        private Connection connection;
+        private EJBReceiver receiver;
+
+        private ClosableContextSelector(EJBClientContext context, Endpoint endpoint, Connection connection, EJBReceiver receiver) {
+            this.context = context;
+            this.endpoint = endpoint;
+            this.connection = connection;
+            this.receiver = receiver;
         }
 
-        try {
-            String echoValue = getBean(MODULE, log, SB_CLASS, ctx).permitAll("alohomora");
-            Assert.assertEquals(echoValue, "alohomora");
-        } catch (Exception e) {
-            Assert.fail("@PermitAll annotation must allow all users and no users to call the method - principal.");
+        public EJBClientContext getCurrent() {
+            return context;
         }
 
-        try {
-            String echoValue = getBean(MODULE, log, SB_CLASS, ctx).denyAll("alohomora");
-            Assert.fail("@DenyAll annotation must allow all users and no users to call the method");
-        } catch (Exception e) {
-            // expected
-            Assert.assertTrue("Thrown exception must be EJBAccessException, but was different", e instanceof EJBAccessException);
+        public void close() throws IOException {
+            context.unregisterEJBReceiver(receiver);
+            safeClose(connection);
+            safeClose(endpoint);
+            this.context = null;
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/SFSBLifecycleCallback.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/SFSBLifecycleCallback.java
@@ -30,8 +30,6 @@ import javax.ejb.Remote;
 import javax.ejb.Remove;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateful;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
 
 import org.jboss.ejb3.annotation.SecurityDomain;
 import org.jboss.logging.Logger;
@@ -57,8 +55,7 @@ public class SFSBLifecycleCallback implements IBeanLifecycleCallback {
     }
 
     @PostConstruct
-    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void init() {
+    public void init() throws Exception {
         // on Stateful bean is permitted to call getCallerPrincipal on @PostConstruct
         ITestResultsSingleton results = this.getSingleton();
 
@@ -68,8 +65,7 @@ public class SFSBLifecycleCallback implements IBeanLifecycleCallback {
     }
 
     @PreDestroy
-    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void tearDown() {
+    public void tearDown() throws Exception {
         // on Stateful bean is permitted to call getCallerPrincipal on @PreDestroy
         ITestResultsSingleton results = this.getSingleton();
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/xa/XaDataSourcePoolStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/xa/XaDataSourcePoolStatisticsTestCase.java
@@ -87,7 +87,7 @@ public class XaDataSourcePoolStatisticsTestCase {
 
     @Before
     public void beforeTest() throws Exception {
-        //TODO Elytron
+        // TODO Elytron: Determine how this should be adapted once the transaction client changes are in
         //final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
         //EJBClientTransactionContext.setGlobalContext(localUserTxContext);
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -143,7 +143,6 @@ public class RemoteNamingEjbTestCase {
                 // expected
             }
 
-
             // test binding
             binder = (BinderRemote) ctx.lookup(ARCHIVE_NAME + "/" + Singleton.class.getSimpleName() + "!" + BinderRemote.class.getName());
             assertNotNull(binder);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
@@ -26,21 +26,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 
 /**
  * @author Paul Ferraro
  */
 public class EJBClientContextSelector {
-    public static ContextSelector<EJBClientContext> setup(String file) throws IOException {
+    public static EJBClientContext setup(String file) throws IOException {
         return setup(file, null);
     }
 
-    public static ContextSelector<EJBClientContext> setup(String file, Properties propertiesToReplace) throws IOException {
+    public static EJBClientContext setup(String file, Properties propertiesToReplace) throws IOException {
         // setUp the selector
         final InputStream inputStream = EJBClientContextSelector.class.getClassLoader().getResourceAsStream(file);
         if (inputStream == null) {
@@ -56,9 +52,8 @@ public class EJBClientContextSelector {
             }
         }
 
-        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
-        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
-
-        return EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using properties
+        return null;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+
+/**
+ * @author Paul Ferraro
+ */
+public class EJBClientContextSelector {
+    public static ContextSelector<EJBClientContext> setup(String file) throws IOException {
+        return setup(file, null);
+    }
+
+    public static ContextSelector<EJBClientContext> setup(String file, Properties propertiesToReplace) throws IOException {
+        // setUp the selector
+        final InputStream inputStream = EJBClientContextSelector.class.getClassLoader().getResourceAsStream(file);
+        if (inputStream == null) {
+            throw new IllegalStateException("Could not find " + file + " in classpath");
+        }
+        final Properties properties = new Properties();
+        properties.load(inputStream);
+
+        // add or replace properties passed from file
+        if (propertiesToReplace != null) {
+            for (Object key: propertiesToReplace.keySet()) {
+                properties.put(key, propertiesToReplace.get(key));
+            }
+        }
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+
+        return EJBClientContext.setSelector(selector);
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -6,6 +6,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopology;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetriever;
@@ -13,6 +14,8 @@ import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetri
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -46,6 +49,8 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
 
     @Test
     public void test() throws Exception {
+
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ClusterTopologyRetriever bean = directory.lookupStateless(ClusterTopologyRetrieverBean.class, ClusterTopologyRetriever.class);
@@ -90,6 +95,11 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
             assertTrue(topology.getNodes().toString() + " should contain " + NODE_1, topology.getNodes().contains(NODE_1));
             assertTrue(topology.getNodes().toString() + " should contain " + NODE_2, topology.getNodes().contains(NODE_2));
             assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
+        } finally {
+            // reset the selector
+            if (selector != null) {
+                EJBClientContext.setSelector(selector);
+            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -14,8 +14,6 @@ import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetri
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -50,7 +48,10 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
     @Test
     public void test() throws Exception {
 
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ClusterTopologyRetriever bean = directory.lookupStateless(ClusterTopologyRetrieverBean.class, ClusterTopologyRetriever.class);
@@ -95,11 +96,6 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
             assertTrue(topology.getNodes().toString() + " should contain " + NODE_1, topology.getNodes().contains(NODE_1));
             assertTrue(topology.getNodes().toString() + " should contain " + NODE_2, topology.getNodes().contains(NODE_2));
             assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
-        } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -45,6 +45,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.InfinispanExceptionThrowingIncrementorBean;
@@ -56,6 +57,8 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementor
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -71,7 +74,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - remoting 4 integration
 public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     private static final String MODULE_NAME = "remote-failover-test";
     private static final String CLIENT_PROPERTIES = "org/jboss/as/test/clustering/cluster/ejb/remote/jboss-ejb-client.properties";
@@ -117,6 +119,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     private void testStatelessFailover(String properties, Class<? extends Incrementor> beanClass) throws Exception {
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(properties);
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = context.lookupStateless(beanClass, Incrementor.class);
 
@@ -188,12 +191,15 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 int frequency = Collections.frequency(results, node);
                 assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
             }
+        } finally {
+            EJBClientContext.setSelector(selector);
         }
     }
 
     @InSequence(2)
     @Test
     public void testStatefulFailover() throws Exception {
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = context.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 
@@ -273,6 +279,8 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 Assert.assertEquals(count++, result.getValue().intValue());
                 Assert.assertEquals(String.valueOf(i), target, result.getNode());
             }
+        } finally {
+            EJBClientContext.setSelector(selector);
         }
     }
 
@@ -288,6 +296,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     public void testConcurrentFailover(Lifecycle lifecycle) throws Exception {
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = directory.lookupStateful(SlowToDestroyStatefulIncrementorBean.class, Incrementor.class);
             AtomicInteger count = new AtomicInteger();
@@ -331,6 +340,8 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 executor.shutdownNow();
             }
+        } finally {
+            EJBClientContext.setSelector(selector);
         }
     }
 
@@ -340,6 +351,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     @InSequence(5)
     @Test
     public void testClientException() throws Exception {
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = context.lookupStateful(InfinispanExceptionThrowingIncrementorBean.class, Incrementor.class);
 
@@ -348,6 +360,8 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             assertTrue("Expected exception wrapped in EJBException", ejbException instanceof EJBException);
             assertNull("Cause of EJBException has not been removed", ejbException.getCause());
             return;
+        } finally {
+            EJBClientContext.setSelector(selector);
         }
         fail("Expected EJBException but didn't catch it");
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -57,8 +57,6 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementor
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -119,7 +117,10 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     private void testStatelessFailover(String properties, Class<? extends Incrementor> beanClass) throws Exception {
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(properties);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using properties and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(properties);
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = context.lookupStateless(beanClass, Incrementor.class);
 
@@ -191,15 +192,16 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 int frequency = Collections.frequency(results, node);
                 assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
             }
-        } finally {
-            EJBClientContext.setSelector(selector);
         }
     }
 
     @InSequence(2)
     @Test
     public void testStatefulFailover() throws Exception {
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = context.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 
@@ -279,8 +281,6 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 Assert.assertEquals(count++, result.getValue().intValue());
                 Assert.assertEquals(String.valueOf(i), target, result.getNode());
             }
-        } finally {
-            EJBClientContext.setSelector(selector);
         }
     }
 
@@ -296,7 +296,10 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     public void testConcurrentFailover(Lifecycle lifecycle) throws Exception {
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = directory.lookupStateful(SlowToDestroyStatefulIncrementorBean.class, Incrementor.class);
             AtomicInteger count = new AtomicInteger();
@@ -340,8 +343,6 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 executor.shutdownNow();
             }
-        } finally {
-            EJBClientContext.setSelector(selector);
         }
     }
 
@@ -351,7 +352,10 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     @InSequence(5)
     @Test
     public void testClientException() throws Exception {
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             Incrementor bean = context.lookupStateful(InfinispanExceptionThrowingIncrementorBean.class, Incrementor.class);
 
@@ -360,8 +364,6 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             assertTrue("Expected exception wrapped in EJBException", ejbException instanceof EJBException);
             assertNull("Cause of EJBException has not been removed", ejbException.getCause());
             return;
-        } finally {
-            EJBClientContext.setSelector(selector);
         }
         fail("Expected EJBException but didn't catch it");
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -9,11 +9,14 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriever;
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -47,6 +50,8 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
     @Test
     public void test() throws Exception {
 
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ServiceProviderRetriever bean = directory.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
             Collection<String> names = bean.getProviders();
@@ -79,6 +84,11 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
             assertEquals(2, names.size());
             assertTrue(names.contains(NODE_1));
             assertTrue(names.contains(NODE_2));
+        } finally {
+            // reset the selector
+            if (selector != null) {
+                EJBClientContext.setSelector(selector);
+            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -15,8 +15,6 @@ import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriev
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -49,8 +47,10 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
 
     @Test
     public void test() throws Exception {
-
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+       EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ServiceProviderRetriever bean = directory.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
@@ -84,11 +84,6 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
             assertEquals(2, names.size());
             assertTrue(names.contains(NODE_1));
             assertTrue(names.contains(NODE_2));
-        } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
@@ -17,8 +17,6 @@ import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetriever;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -55,7 +53,10 @@ public class RegistryTestCase extends ClusterAbstractTestCase {
     @Test
     public void test() throws Exception {
 
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             RegistryRetriever bean = context.lookupStateless(RegistryRetrieverBean.class, RegistryRetriever.class);
@@ -89,11 +90,6 @@ public class RegistryTestCase extends ClusterAbstractTestCase {
             assertEquals(2, names.size());
             assertTrue(names.contains(NODE_1));
             assertTrue(names.contains(NODE_2));
-        } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
@@ -11,11 +11,14 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetriever;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -24,7 +27,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client 4 integration
 public class RegistryTestCase extends ClusterAbstractTestCase {
     private static final String MODULE_NAME = "registry";
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
@@ -52,6 +54,9 @@ public class RegistryTestCase extends ClusterAbstractTestCase {
 
     @Test
     public void test() throws Exception {
+
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             RegistryRetriever bean = context.lookupStateless(RegistryRetrieverBean.class, RegistryRetriever.class);
             Collection<String> names = bean.getNodes();
@@ -84,6 +89,11 @@ public class RegistryTestCase extends ClusterAbstractTestCase {
             assertEquals(2, names.size());
             assertTrue(names.contains(NODE_1));
             assertTrue(names.contains(NODE_2));
+        } finally {
+            // reset the selector
+            if (selector != null) {
+                EJBClientContext.setSelector(selector);
+            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -43,7 +43,6 @@ import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.ejb.client.ClusterContext;
-import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
@@ -71,7 +70,6 @@ public abstract class ClusterPassivationTestBase {
     }
 
     // Properties pass amongst tests
-    protected static ContextSelector<EJBClientContext> previousSelector;
     protected static Map<String, String> node2deployment = new HashMap<String, String>();
     protected static Map<String, String> node2container = new HashMap<String, String>();
 
@@ -94,7 +92,10 @@ public abstract class ClusterPassivationTestBase {
      * specific jboss-ejb-client.properties file
      */
     protected void setupEJBClientContextSelector() throws IOException {
-        previousSelector = EJBClientContextSelector
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using sfsb-failover-jboss-ejb-client.properties and ensure the EJB client
+        // context is reset to its original state at the end of the test
+        EJBClientContextSelector
                 .setup("cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties");
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_LOOP_COUNT;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_WAIT_MS;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_NAME;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.WAIT_FOR_PASSIVATION_MS;
 
 import java.io.IOException;
@@ -42,7 +39,6 @@ import org.jboss.as.test.clustering.DMRUtil;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ClusterContext;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
@@ -113,14 +109,15 @@ public abstract class ClusterPassivationTestBase {
     protected void waitForClusterContext() throws InterruptedException {
         int counter = 0;
         EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
-        ClusterContext clusterContext;
-        do {
-            clusterContext = ejbClientContext.getClusterContext(CLUSTER_NAME);
-            counter--;
-            Thread.sleep(CLUSTER_ESTABLISHMENT_WAIT_MS);
-        } while (clusterContext == null && counter < CLUSTER_ESTABLISHMENT_LOOP_COUNT);
-        Assert.assertNotNull("Cluster context for " + CLUSTER_NAME + " was not taken in "
-                + (CLUSTER_ESTABLISHMENT_LOOP_COUNT * CLUSTER_ESTABLISHMENT_WAIT_MS) + " ms", clusterContext);
+        // TODO Elytron: Determine how this should be adapted once the clustering and EJB client changes are in
+        // ClusterContext clusterContext;
+        //do {
+        //    clusterContext = ejbClientContext.getClusterContext(CLUSTER_NAME);
+        //    counter--;
+        //    Thread.sleep(CLUSTER_ESTABLISHMENT_WAIT_MS);
+        //} while (clusterContext == null && counter < CLUSTER_ESTABLISHMENT_LOOP_COUNT);
+        //Assert.assertNotNull("Cluster context for " + CLUSTER_NAME + " was not taken in "
+        //        + (CLUSTER_ESTABLISHMENT_LOOP_COUNT * CLUSTER_ESTABLISHMENT_WAIT_MS) + " ms", clusterContext);
     }
 
     /**
@@ -141,7 +138,8 @@ public abstract class ClusterPassivationTestBase {
 
         // A small hack - deleting node (by name) from cluster which this client knows
         // It means that the next request (ejb call) will be passed to the server #2
-        EJBClientContext.requireCurrent().getClusterContext(CLUSTER_NAME).removeClusterNode(calledNodeFirst);
+        // TODO Elytron: Determine how this should be adapted once the clustering and EJB client changes are in
+        //EJBClientContext.requireCurrent().getClusterContext(CLUSTER_NAME).removeClusterNode(calledNodeFirst);
 
         Assert.assertEquals("Supposing to get passivation node which was set", calledNodeFirst, statefulBean.getPassivatedBy());
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.clustering.NodeInfoServlet;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -152,11 +151,6 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
             @OperateOnDeployment(DEPLOYMENT_1) @ArquillianResource ManagementClient client1,
             @OperateOnDeployment(DEPLOYMENT_2) @ArquillianResource ManagementClient client2) throws Exception {
         log.trace("Stop&Clean...");
-
-        // returning to the previous context selector, @see {RemoteEJBClientDDBasedSFSBFailoverTestCase}
-        if (previousSelector != null) {
-            EJBClientContext.setSelector(previousSelector);
-        }
 
         // unset & undeploy & stop
         if (client1.isServerInRunningState()) {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
@@ -42,7 +42,6 @@ import org.jboss.as.test.clustering.extended.ejb2.stateful.passivation.StatefulB
 import org.jboss.as.test.clustering.extended.ejb2.stateful.passivation.StatefulRemote;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.passivation.StatefulRemoteHome;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -151,11 +150,6 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
             @OperateOnDeployment(DEPLOYMENT_1) @ArquillianResource ManagementClient client1,
             @OperateOnDeployment(DEPLOYMENT_2) @ArquillianResource ManagementClient client2) throws Exception {
         log.trace("Stop&Clean...");
-
-        // returning to the previous context selector, @see {RemoteEJBClientDDBasedSFSBFailoverTestCase}
-        if (previousSelector != null) {
-            EJBClientContext.setSelector(previousSelector);
-        }
 
         // unset & undeploy & stop
         if (client1.isServerInRunningState()) {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -28,8 +28,6 @@ import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -103,77 +101,74 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends ClusterAbs
      * Implementation of defined abstract tests above.
      */
     protected void failoverFromRemoteClient(boolean undeployOnly) throws Exception {
-        final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(PROPERTIES_FILE);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using PROPERTIES_FILE and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(PROPERTIES_FILE);
 
-        try {
-            CounterRemoteHome home = directory.lookupHome(CounterBean.class, CounterRemoteHome.class);
-            CounterRemote remoteCounter = home.create();
-            Assert.assertNotNull(remoteCounter);
 
-            final CounterSingletonRemote destructionCounter = singletonDirectory.lookupSingleton(CounterSingleton.class, CounterSingletonRemote.class);
-            destructionCounter.resetDestroyCount();
+        CounterRemoteHome home = directory.lookupHome(CounterBean.class, CounterRemoteHome.class);
+        CounterRemote remoteCounter = home.create();
+        Assert.assertNotNull(remoteCounter);
 
-            // invoke on the bean a few times
-            final int NUM_TIMES = 25;
-            for (int i = 0; i < NUM_TIMES; i++) {
-                final CounterResult result = remoteCounter.increment();
-                log.trace("Counter incremented to " + result.getCount() + " on node " + result.getNodeName());
-            }
-            final CounterResult result = remoteCounter.getCount();
-            Assert.assertNotNull("Result from remote stateful counter was null", result);
-            Assert.assertEquals("Unexpected count from remote counter", NUM_TIMES, result.getCount());
-            Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
+        final CounterSingletonRemote destructionCounter = singletonDirectory.lookupSingleton(CounterSingleton.class, CounterSingletonRemote.class);
+        destructionCounter.resetDestroyCount();
 
-            // shutdown the node on which the previous invocation happened
-            final int totalCountBeforeShuttingDownANode = result.getCount();
-            final String previousInvocationNodeName = result.getNodeName();
-            // the value is configured in arquillian.xml of the project
-            if (previousInvocationNodeName.equals(NODE_1)) {
-                if (undeployOnly) {
-                    deployer.undeploy(DEPLOYMENT_1);
-                    deployer.undeploy(DEPLOYMENT_HELPER_1);
-                } else {
-                    stop(CONTAINER_1);
-                }
+        // invoke on the bean a few times
+        final int NUM_TIMES = 25;
+        for (int i = 0; i < NUM_TIMES; i++) {
+            final CounterResult result = remoteCounter.increment();
+            log.trace("Counter incremented to " + result.getCount() + " on node " + result.getNodeName());
+        }
+        final CounterResult result = remoteCounter.getCount();
+        Assert.assertNotNull("Result from remote stateful counter was null", result);
+        Assert.assertEquals("Unexpected count from remote counter", NUM_TIMES, result.getCount());
+        Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
+
+        // shutdown the node on which the previous invocation happened
+        final int totalCountBeforeShuttingDownANode = result.getCount();
+        final String previousInvocationNodeName = result.getNodeName();
+        // the value is configured in arquillian.xml of the project
+        if (previousInvocationNodeName.equals(NODE_1)) {
+            if (undeployOnly) {
+                deployer.undeploy(DEPLOYMENT_1);
+                deployer.undeploy(DEPLOYMENT_HELPER_1);
             } else {
-                if (undeployOnly) {
-                    deployer.undeploy(DEPLOYMENT_2);
-                    deployer.undeploy(DEPLOYMENT_HELPER_2);
-                } else {
-                    stop(CONTAINER_2);
-                }
+                stop(CONTAINER_1);
             }
-            // invoke again
-            CounterResult resultAfterShuttingDownANode = remoteCounter.increment();
-            Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
-            Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", totalCountBeforeShuttingDownANode + 1, resultAfterShuttingDownANode.getCount());
-            Assert.assertFalse("Result was received from an unexpected node, after shutting down a node", previousInvocationNodeName.equals(resultAfterShuttingDownANode.getNodeName()));
-
-            // repeat invocations
-            final int countBeforeDecrementing = resultAfterShuttingDownANode.getCount();
-            final String aliveNode = resultAfterShuttingDownANode.getNodeName();
-            for (int i = NUM_TIMES; i > 0; i--) {
-                resultAfterShuttingDownANode = remoteCounter.decrement();
-                Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
-                Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, resultAfterShuttingDownANode.getNodeName());
-                log.trace("Counter decremented to " + resultAfterShuttingDownANode.getCount() + " on node " + resultAfterShuttingDownANode.getNodeName());
-            }
-            final CounterResult finalResult = remoteCounter.getCount();
-            Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", finalResult);
-            final int finalCount = finalResult.getCount();
-            final String finalNodeName = finalResult.getNodeName();
-            Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, finalNodeName);
-            Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", countBeforeDecrementing - NUM_TIMES, finalCount);
-
-
-            Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
-            remoteCounter.remove();
-            Assert.assertEquals("SFSB was not destroyed", 1, destructionCounter.getDestroyCount());
-        } finally {
-            // reset the selector
-            if (previousSelector != null) {
-                EJBClientContext.setSelector(previousSelector);
+        } else {
+            if (undeployOnly) {
+                deployer.undeploy(DEPLOYMENT_2);
+                deployer.undeploy(DEPLOYMENT_HELPER_2);
+            } else {
+                stop(CONTAINER_2);
             }
         }
+        // invoke again
+        CounterResult resultAfterShuttingDownANode = remoteCounter.increment();
+        Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
+        Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", totalCountBeforeShuttingDownANode + 1, resultAfterShuttingDownANode.getCount());
+        Assert.assertFalse("Result was received from an unexpected node, after shutting down a node", previousInvocationNodeName.equals(resultAfterShuttingDownANode.getNodeName()));
+
+        // repeat invocations
+        final int countBeforeDecrementing = resultAfterShuttingDownANode.getCount();
+        final String aliveNode = resultAfterShuttingDownANode.getNodeName();
+        for (int i = NUM_TIMES; i > 0; i--) {
+            resultAfterShuttingDownANode = remoteCounter.decrement();
+            Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
+            Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, resultAfterShuttingDownANode.getNodeName());
+            log.trace("Counter decremented to " + resultAfterShuttingDownANode.getCount() + " on node " + resultAfterShuttingDownANode.getNodeName());
+        }
+        final CounterResult finalResult = remoteCounter.getCount();
+        Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", finalResult);
+        final int finalCount = finalResult.getCount();
+        final String finalNodeName = finalResult.getNodeName();
+        Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, finalNodeName);
+        Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", countBeforeDecrementing - NUM_TIMES, finalCount);
+
+
+        Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
+        remoteCounter.remove();
+        Assert.assertEquals("SFSB was not destroyed", 1, destructionCounter.getDestroyCount());
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -24,9 +24,12 @@ package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
 
 import javax.naming.NamingException;
 
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -100,68 +103,77 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends ClusterAbs
      * Implementation of defined abstract tests above.
      */
     protected void failoverFromRemoteClient(boolean undeployOnly) throws Exception {
-        CounterRemoteHome home = directory.lookupHome(CounterBean.class, CounterRemoteHome.class);
-        CounterRemote remoteCounter = home.create();
-        Assert.assertNotNull(remoteCounter);
+        final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(PROPERTIES_FILE);
 
-        final CounterSingletonRemote destructionCounter = singletonDirectory.lookupSingleton(CounterSingleton.class, CounterSingletonRemote.class);
-        destructionCounter.resetDestroyCount();
+        try {
+            CounterRemoteHome home = directory.lookupHome(CounterBean.class, CounterRemoteHome.class);
+            CounterRemote remoteCounter = home.create();
+            Assert.assertNotNull(remoteCounter);
 
-        // invoke on the bean a few times
-        final int NUM_TIMES = 25;
-        for (int i = 0; i < NUM_TIMES; i++) {
-            final CounterResult result = remoteCounter.increment();
-            log.trace("Counter incremented to " + result.getCount() + " on node " + result.getNodeName());
-        }
-        final CounterResult result = remoteCounter.getCount();
-        Assert.assertNotNull("Result from remote stateful counter was null", result);
-        Assert.assertEquals("Unexpected count from remote counter", NUM_TIMES, result.getCount());
-        Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
+            final CounterSingletonRemote destructionCounter = singletonDirectory.lookupSingleton(CounterSingleton.class, CounterSingletonRemote.class);
+            destructionCounter.resetDestroyCount();
 
-        // shutdown the node on which the previous invocation happened
-        final int totalCountBeforeShuttingDownANode = result.getCount();
-        final String previousInvocationNodeName = result.getNodeName();
-        // the value is configured in arquillian.xml of the project
-        if (previousInvocationNodeName.equals(NODE_1)) {
-            if (undeployOnly) {
-                deployer.undeploy(DEPLOYMENT_1);
-                deployer.undeploy(DEPLOYMENT_HELPER_1);
-            } else {
-                stop(CONTAINER_1);
+            // invoke on the bean a few times
+            final int NUM_TIMES = 25;
+            for (int i = 0; i < NUM_TIMES; i++) {
+                final CounterResult result = remoteCounter.increment();
+                log.trace("Counter incremented to " + result.getCount() + " on node " + result.getNodeName());
             }
-        } else {
-            if (undeployOnly) {
-                deployer.undeploy(DEPLOYMENT_2);
-                deployer.undeploy(DEPLOYMENT_HELPER_2);
-            } else {
-                stop(CONTAINER_2);
-            }
-        }
-        // invoke again
-        CounterResult resultAfterShuttingDownANode = remoteCounter.increment();
-        Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
-        Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", totalCountBeforeShuttingDownANode + 1, resultAfterShuttingDownANode.getCount());
-        Assert.assertFalse("Result was received from an unexpected node, after shutting down a node", previousInvocationNodeName.equals(resultAfterShuttingDownANode.getNodeName()));
+            final CounterResult result = remoteCounter.getCount();
+            Assert.assertNotNull("Result from remote stateful counter was null", result);
+            Assert.assertEquals("Unexpected count from remote counter", NUM_TIMES, result.getCount());
+            Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
 
-        // repeat invocations
-        final int countBeforeDecrementing = resultAfterShuttingDownANode.getCount();
-        final String aliveNode = resultAfterShuttingDownANode.getNodeName();
-        for (int i = NUM_TIMES; i > 0; i--) {
-            resultAfterShuttingDownANode = remoteCounter.decrement();
+            // shutdown the node on which the previous invocation happened
+            final int totalCountBeforeShuttingDownANode = result.getCount();
+            final String previousInvocationNodeName = result.getNodeName();
+            // the value is configured in arquillian.xml of the project
+            if (previousInvocationNodeName.equals(NODE_1)) {
+                if (undeployOnly) {
+                    deployer.undeploy(DEPLOYMENT_1);
+                    deployer.undeploy(DEPLOYMENT_HELPER_1);
+                } else {
+                    stop(CONTAINER_1);
+                }
+            } else {
+                if (undeployOnly) {
+                    deployer.undeploy(DEPLOYMENT_2);
+                    deployer.undeploy(DEPLOYMENT_HELPER_2);
+                } else {
+                    stop(CONTAINER_2);
+                }
+            }
+            // invoke again
+            CounterResult resultAfterShuttingDownANode = remoteCounter.increment();
             Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
-            Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, resultAfterShuttingDownANode.getNodeName());
-            log.trace("Counter decremented to " + resultAfterShuttingDownANode.getCount() + " on node " + resultAfterShuttingDownANode.getNodeName());
+            Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", totalCountBeforeShuttingDownANode + 1, resultAfterShuttingDownANode.getCount());
+            Assert.assertFalse("Result was received from an unexpected node, after shutting down a node", previousInvocationNodeName.equals(resultAfterShuttingDownANode.getNodeName()));
+
+            // repeat invocations
+            final int countBeforeDecrementing = resultAfterShuttingDownANode.getCount();
+            final String aliveNode = resultAfterShuttingDownANode.getNodeName();
+            for (int i = NUM_TIMES; i > 0; i--) {
+                resultAfterShuttingDownANode = remoteCounter.decrement();
+                Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", resultAfterShuttingDownANode);
+                Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, resultAfterShuttingDownANode.getNodeName());
+                log.trace("Counter decremented to " + resultAfterShuttingDownANode.getCount() + " on node " + resultAfterShuttingDownANode.getNodeName());
+            }
+            final CounterResult finalResult = remoteCounter.getCount();
+            Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", finalResult);
+            final int finalCount = finalResult.getCount();
+            final String finalNodeName = finalResult.getNodeName();
+            Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, finalNodeName);
+            Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", countBeforeDecrementing - NUM_TIMES, finalCount);
+
+
+            Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
+            remoteCounter.remove();
+            Assert.assertEquals("SFSB was not destroyed", 1, destructionCounter.getDestroyCount());
+        } finally {
+            // reset the selector
+            if (previousSelector != null) {
+                EJBClientContext.setSelector(previousSelector);
+            }
         }
-        final CounterResult finalResult = remoteCounter.getCount();
-        Assert.assertNotNull("Result from remote stateful counter, after shutting down a node was null", finalResult);
-        final int finalCount = finalResult.getCount();
-        final String finalNodeName = finalResult.getNodeName();
-        Assert.assertEquals("Result was received from an unexpected node, after shutting down a node", aliveNode, finalNodeName);
-        Assert.assertEquals("Unexpected count from remote counter, after shutting down a node", countBeforeDecrementing - NUM_TIMES, finalCount);
-
-
-        Assert.assertEquals("Nothing should have been destroyed yet", 0, destructionCounter.getDestroyCount());
-        remoteCounter.remove();
-        Assert.assertEquals("SFSB was not destroyed", 1, destructionCounter.getDestroyCount());
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -49,8 +49,6 @@ import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -187,7 +185,10 @@ public class RemoteStatelessFailoverTestCase {
         this.start(CONTAINER_1);
         this.deploy(CONTAINER_1, deployment1);
 
-        final ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try {
             StatelessRemoteHome home = directory.lookupHome(StatelessBean.class, StatelessRemoteHome.class);
@@ -206,10 +207,6 @@ public class RemoteStatelessFailoverTestCase {
 
             assertEquals("Only " + NODES[1] + " is active. The bean had to be invoked on it but it wasn't.", NODES[1], bean.getNodeName());
         } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
             // need to have the container started to undeploy deployment afterwards
             this.start(CONTAINER_1);
             // shutdown the containers
@@ -237,7 +234,10 @@ public class RemoteStatelessFailoverTestCase {
         this.start(CONTAINER_2);
         this.deploy(CONTAINER_2, deployment2);
 
-        final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         int numberOfServers = 2;
         int numberOfCalls = 40;
@@ -264,10 +264,6 @@ public class RemoteStatelessFailoverTestCase {
 
             validateBalancing(bean, numberOfCalls, numberOfServers, serversProccessedAtLeast);
         } finally {
-            // reset the selector
-            if (previousSelector != null) {
-                EJBClientContext.setSelector(previousSelector);
-            }
             // undeploy&shutdown the containers
             undeployAll();
             shutdownAll();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
@@ -27,11 +27,14 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopology;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetriever;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -44,7 +47,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client 4 integration
 public class CommandDispatcherTestCase {
     private static final String MODULE_NAME = "command-dispatcher";
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
@@ -58,12 +60,20 @@ public class CommandDispatcherTestCase {
 
     @Test
     public void test() throws Exception {
+
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ClusterTopologyRetriever bean = directory.lookupStateless(ClusterTopologyRetrieverBean.class, ClusterTopologyRetriever.class);
             ClusterTopology topology = bean.getClusterTopology();
             assertEquals(1, topology.getNodes().size());
             assertTrue(topology.getNodes().toString(), topology.getNodes().contains(NODE_1));
             assertTrue(topology.getRemoteNodes().toString() + " should be empty", topology.getRemoteNodes().isEmpty());
+        } finally {
+            // reset the selector
+            if (selector != null) {
+                EJBClientContext.setSelector(selector);
+            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
@@ -33,7 +33,6 @@ import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetri
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -61,7 +60,10 @@ public class CommandDispatcherTestCase {
     @Test
     public void test() throws Exception {
 
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContext selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ClusterTopologyRetriever bean = directory.lookupStateless(ClusterTopologyRetrieverBean.class, ClusterTopologyRetriever.class);
@@ -69,11 +71,6 @@ public class CommandDispatcherTestCase {
             assertEquals(1, topology.getNodes().size());
             assertTrue(topology.getNodes().toString(), topology.getNodes().contains(NODE_1));
             assertTrue(topology.getRemoteNodes().toString() + " should be empty", topology.getRemoteNodes().isEmpty());
-        } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
@@ -36,8 +36,6 @@ import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriev
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -67,18 +65,16 @@ public class ServiceProviderRegistrationTestCase {
     @Test
     public void test() throws Exception {
 
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
             ServiceProviderRetriever bean = directory.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
             Collection<String> names = bean.getProviders();
             assertEquals(1, names.size());
             assertTrue(names.toString(), names.contains(NODE_1));
-        } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
@@ -31,10 +31,13 @@ import java.util.PropertyPermission;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetriever;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -47,7 +50,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client4 integration
 public class RegistryTestCase {
     private static final String MODULE_NAME = "registry";
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
@@ -64,11 +66,19 @@ public class RegistryTestCase {
 
     @Test
     public void test() throws Exception {
+
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             RegistryRetriever bean = context.lookupStateless(RegistryRetrieverBean.class, RegistryRetriever.class);
             Collection<String> names = bean.getNodes();
             assertEquals(1, names.size());
             assertTrue(names.toString(), names.contains(NODE_1));
+        } finally {
+            // reset the selector
+            if (selector != null) {
+                EJBClientContext.setSelector(selector);
+            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
@@ -36,8 +36,6 @@ import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetriever;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -67,18 +65,16 @@ public class RegistryTestCase {
     @Test
     public void test() throws Exception {
 
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             RegistryRetriever bean = context.lookupStateless(RegistryRetrieverBean.class, RegistryRetriever.class);
             Collection<String> names = bean.getNodes();
             assertEquals(1, names.size());
             assertTrue(names.toString(), names.contains(NODE_1));
-        } finally {
-            // reset the selector
-            if (selector != null) {
-                EJBClientContext.setSelector(selector);
-            }
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
@@ -16,8 +16,6 @@ import org.jboss.as.test.clustering.twoclusters.bean.forwarding.ForwardingStatef
 import org.jboss.as.test.clustering.twoclusters.bean.forwarding.NonTxForwardingStatefulSBImpl;
 import org.jboss.as.test.clustering.twoclusters.bean.stateful.RemoteStatefulSB;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -200,113 +198,111 @@ public class RemoteEJBTwoClusterTestCase extends ExtendedClusterAbstractTestCase
      * as long as one node in each cluster is available.
      */
     public void testConcurrentFailoverOverWithTwoClusters(boolean useTransactions) throws Exception {
-        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(FORWARDER_CLIENT_PROPERTIES);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using FORWARDER_CLIENT_PROPERTIES and ensure the EJB client context is reset
+        // to its original state at the end of the test
+        EJBClientContextSelector.setup(FORWARDER_CLIENT_PROPERTIES);
 
         try {
+            // get the correct forwarder deployment on cluster A
+            RemoteStatefulSB bean = null;
+            if (useTransactions)
+                bean = txnBeanDirectory.lookupStateful(ForwardingStatefulSBImpl.class, RemoteStatefulSB.class);
+            else
+                bean = beanDirectory.lookupStateful(NonTxForwardingStatefulSBImpl.class, RemoteStatefulSB.class);
+
+            AtomicInteger count = new AtomicInteger();
+
+            // Allow sufficient time for client to receive full topology
+            logger.trace("Waiting for clusters to form:");
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            int newSerialValue = bean.getSerialAndIncrement();
+            int newCountValue = count.getAndIncrement();
+            logger.trace("First invocation: count = " + newCountValue + ", serial = " + newSerialValue);
+
+            //
+            ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+            CountDownLatch latch = new CountDownLatch(1);
+            ClientInvocationTask client = new ClientInvocationTask(bean, latch, count);
+
             try {
-                // get the correct forwarder deployment on cluster A
-                RemoteStatefulSB bean = null;
-                if (useTransactions)
-                    bean = txnBeanDirectory.lookupStateful(ForwardingStatefulSBImpl.class, RemoteStatefulSB.class);
-                else
-                    bean = beanDirectory.lookupStateful(NonTxForwardingStatefulSBImpl.class, RemoteStatefulSB.class);
+                // set up the client invocations
+                Future<?> future = executor.scheduleWithFixedDelay(client, 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
+                latch.await();
 
-                AtomicInteger count = new AtomicInteger();
+                // a few seconds of non-failure behaviour
+                Thread.sleep(FAILURE_FREE_TIME);
 
-                // Allow sufficient time for client to receive full topology
-                logger.trace("Waiting for clusters to form:");
-                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+                logger.trace("------ Shutdown clusterA-node0 -----");
+                // stop cluster A node 0
+                stop(CONTAINER_1);
+                // Let the server stay down for a while
+                Thread.sleep(SERVER_DOWN_TIME);
+                logger.trace("------ Startup clusterA-node0 -----");
+                start(CONTAINER_1);
 
-                int newSerialValue = bean.getSerialAndIncrement();
-                int newCountValue = count.getAndIncrement();
-                logger.trace("First invocation: count = " + newCountValue + ", serial = " + newSerialValue);
+                // a few seconds of non-failure behaviour
+                Thread.sleep(FAILURE_FREE_TIME);
 
-                //
-                ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-                CountDownLatch latch = new CountDownLatch(1);
-                ClientInvocationTask client = new ClientInvocationTask(bean, latch, count);
+                logger.trace("----- Shutdown clusterA-node1 -----");
+                // stop cluster A node 1
+                stop(CONTAINER_2);
+                // Let the server stay down for a while
+                Thread.sleep(SERVER_DOWN_TIME);
+                logger.trace("------ Startup clusterA-node1 -----");
+                start(CONTAINER_2);
 
+                // a few seconds of non-failure behaviour
+                Thread.sleep(FAILURE_FREE_TIME);
+
+                logger.trace("----- Shutdown clusterB-node0 -----");
+                // stop cluster B node 0
+                stop(CONTAINER_3);
+                // Let the server stay down for a while
+                Thread.sleep(SERVER_DOWN_TIME);
+                logger.trace("------ Startup clusterB-node0 -----");
+                start(CONTAINER_3);
+
+                // a few seconds of non-failure behaviour
+                Thread.sleep(FAILURE_FREE_TIME);
+
+                logger.trace("----- Shutdown clusterB-node1 -----");
+                // stop cluster B node 1
+                stop(CONTAINER_4);
+                // Let the server stay down for a while
+                Thread.sleep(SERVER_DOWN_TIME);
+                logger.trace("------ Startup clusterB-node1 -----");
+                start(CONTAINER_4);
+
+                // a few seconds of non-failure behaviour
+                Thread.sleep(FAILURE_FREE_TIME);
+
+                // cancel the executor and wait for it to complete
+                future.cancel(false);
                 try {
-                    // set up the client invocations
-                    Future<?> future = executor.scheduleWithFixedDelay(client, 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
-                    latch.await();
-
-                    // a few seconds of non-failure behaviour
-                    Thread.sleep(FAILURE_FREE_TIME);
-
-                    logger.trace("------ Shutdown clusterA-node0 -----");
-                    // stop cluster A node 0
-                    stop(CONTAINER_1);
-                    // Let the server stay down for a while
-                    Thread.sleep(SERVER_DOWN_TIME);
-                    logger.trace("------ Startup clusterA-node0 -----");
-                    start(CONTAINER_1);
-
-                    // a few seconds of non-failure behaviour
-                    Thread.sleep(FAILURE_FREE_TIME);
-
-                    logger.trace("----- Shutdown clusterA-node1 -----");
-                    // stop cluster A node 1
-                    stop(CONTAINER_2);
-                    // Let the server stay down for a while
-                    Thread.sleep(SERVER_DOWN_TIME);
-                    logger.trace("------ Startup clusterA-node1 -----");
-                    start(CONTAINER_2);
-
-                    // a few seconds of non-failure behaviour
-                    Thread.sleep(FAILURE_FREE_TIME);
-
-                    logger.trace("----- Shutdown clusterB-node0 -----");
-                    // stop cluster B node 0
-                    stop(CONTAINER_3);
-                    // Let the server stay down for a while
-                    Thread.sleep(SERVER_DOWN_TIME);
-                    logger.trace("------ Startup clusterB-node0 -----");
-                    start(CONTAINER_3);
-
-                    // a few seconds of non-failure behaviour
-                    Thread.sleep(FAILURE_FREE_TIME);
-
-                    logger.trace("----- Shutdown clusterB-node1 -----");
-                    // stop cluster B node 1
-                    stop(CONTAINER_4);
-                    // Let the server stay down for a while
-                    Thread.sleep(SERVER_DOWN_TIME);
-                    logger.trace("------ Startup clusterB-node1 -----");
-                    start(CONTAINER_4);
-
-                    // a few seconds of non-failure behaviour
-                    Thread.sleep(FAILURE_FREE_TIME);
-
-                    // cancel the executor and wait for it to complete
-                    future.cancel(false);
-                    try {
-                        future.get();
-                    } catch (CancellationException e) {
-                        logger.trace("Could not cancel future: " + e.toString());
-                    }
-
-                    // test is completed, report results
-                    double invocations = client.getInvocationCount();
-                    double exceptions = client.getExceptionCount();
-                    logger.trace("Total invocations = " + invocations + ", total exceptions = " + exceptions);
-                    Assert.assertTrue("Too many exceptions! percentage = " + 100 * (exceptions/invocations), (exceptions/invocations) < EXCEPTION_PERCENTAGE);
-
-                } catch (Exception e) {
-                    Assert.fail("Exception occurred on client: " + e.getMessage() + ", test did not complete successfully (inner)");
-
-                } finally {
-                    logger.trace("Shutting down executor");
-                    executor.shutdownNow();
+                    future.get();
+                } catch (CancellationException e) {
+                    logger.trace("Could not cancel future: " + e.toString());
                 }
 
-            } catch (Exception e) {
-                Assert.fail("Exception occurred on client: " + e.getMessage() + ", test did not complete successfully (outer)");
+                // test is completed, report results
+                double invocations = client.getInvocationCount();
+                double exceptions = client.getExceptionCount();
+                logger.trace("Total invocations = " + invocations + ", total exceptions = " + exceptions);
+                Assert.assertTrue("Too many exceptions! percentage = " + 100 * (exceptions/invocations), (exceptions/invocations) < EXCEPTION_PERCENTAGE);
 
+            } catch (Exception e) {
+                Assert.fail("Exception occurred on client: " + e.getMessage() + ", test did not complete successfully (inner)");
+
+            } finally {
+                logger.trace("Shutting down executor");
+                executor.shutdownNow();
             }
-        } finally {
-            // reset the EJBClient context to the original instance
-            EJBClientContext.setSelector(selector);
+
+        } catch (Exception e) {
+            Assert.fail("Exception occurred on client: " + e.getMessage() + ", test did not complete successfully (outer)");
+
         }
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -37,11 +37,7 @@ import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.manualmode.ejb.Util;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -99,21 +95,17 @@ public class EJBClientClusterConfigurationTestCase {
     private Deployer deployer;
 
     private Context context;
-    private ContextSelector<EJBClientContext> previousClientContextSelector;
 
     @Before
     public void before() throws Exception {
         this.context = Util.createNamingContext();
         // setup the client context selector
-        this.previousClientContextSelector = setupEJBClientContextSelector();
+        setupEJBClientContextSelector();
 
     }
 
     @After
     public void after() throws NamingException {
-        if (this.previousClientContextSelector != null) {
-            EJBClientContext.setSelector(this.previousClientContextSelector);
-        }
         this.context.close();
     }
 
@@ -220,7 +212,7 @@ public class EJBClientClusterConfigurationTestCase {
      * @return
      * @throws java.io.IOException
      */
-    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+    private static EJBClientContext setupEJBClientContextSelector() throws IOException {
         // setup the selector
         final String clientPropertiesFile = "jboss-ejb-client.properties";
         final InputStream inputStream = EJBClientClusterConfigurationTestCase.class.getResourceAsStream(clientPropertiesFile);
@@ -229,10 +221,9 @@ public class EJBClientClusterConfigurationTestCase {
         }
         final Properties properties = new Properties();
         properties.load(inputStream);
-        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
-        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
-
-        return EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using properties
+        return null;
     }
 
     private static ModelControllerClient createModelControllerClient(final String container) throws UnknownHostException {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
@@ -30,11 +30,7 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.manualmode.ejb.Util;
-import org.jboss.ejb.client.ContextSelector;
-import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -81,20 +77,16 @@ public class RemoteOutboundConnectionReconnectTestCase {
     private Deployer deployer;
 
     private Context context;
-    private ContextSelector<EJBClientContext> previousClientContextSelector;
 
     @Before
     public void before() throws Exception {
         this.context = Util.createNamingContext();
         // setup the client context selector
-        this.previousClientContextSelector = setupEJBClientContextSelector();
+        setupEJBClientContextSelector();
     }
 
     @After
     public void after() throws NamingException {
-        if (this.previousClientContextSelector != null) {
-            EJBClientContext.setSelector(this.previousClientContextSelector);
-        }
         this.context.close();
     }
 
@@ -261,7 +253,7 @@ public class RemoteOutboundConnectionReconnectTestCase {
      * @return
      * @throws java.io.IOException
      */
-    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+    private static EJBClientContext setupEJBClientContextSelector() throws IOException {
         // setup the selector
         final String clientPropertiesFile = "org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.properties";
         final InputStream inputStream = RemoteOutboundConnectionReconnectTestCase.class.getClassLoader().getResourceAsStream(clientPropertiesFile);
@@ -270,9 +262,8 @@ public class RemoteOutboundConnectionReconnectTestCase {
         }
         final Properties properties = new Properties();
         properties.load(inputStream);
-        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
-        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
-
-        return EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using properties
+        return null;
     }
 }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
@@ -131,8 +131,9 @@ public class EJBClientReconnectionTestCase {
 
     @Test
     public void testReconnectionWithClientAPI() throws Throwable {
-        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
-        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+        // TODO Elytron: Determine how this should be adapted once the transaction client changes are in
+        //final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        //EJBClientTransactionContext.setGlobalContext(localUserTxContext);
 
         final StatelessEJBLocator<SimpleCrashBeanRemote> locator = new StatelessEJBLocator(SimpleCrashBeanRemote.class, "", DEPLOYMENT, SimpleCrashBean.class.getSimpleName(), "");
         final SimpleCrashBeanRemote proxy = EJBClient.createProxy(locator);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
@@ -29,14 +29,10 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.manualmode.ejb.Util;
-import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClient;
-import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.EJBClientTransactionContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
 import org.jboss.ejb.client.StatelessEJBLocator;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -78,7 +74,6 @@ public class EJBClientReconnectionTestCase {
     private Deployer deployer;
 
     private Context context;
-    private ContextSelector<EJBClientContext> previousClientContextSelector;
 
 
     @Deployment(name = DEPLOYMENT, managed = false, testable = false)
@@ -92,7 +87,7 @@ public class EJBClientReconnectionTestCase {
     public void before() throws Exception {
         this.context = Util.createNamingContext();
         // setup the client context selector
-        this.previousClientContextSelector = setupEJBClientContextSelector();
+        setupEJBClientContextSelector();
 
         controller.start(CONTAINER);
         log.trace("===appserver started===");
@@ -102,9 +97,6 @@ public class EJBClientReconnectionTestCase {
 
     @After
     public void after() throws Exception {
-        if (this.previousClientContextSelector != null) {
-            EJBClientContext.setSelector(this.previousClientContextSelector);
-        }
         this.context.close();
 
         try {
@@ -182,7 +174,7 @@ public class EJBClientReconnectionTestCase {
      * @return
      * @throws java.io.IOException
      */
-    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+    private static EJBClientContext setupEJBClientContextSelector() throws IOException {
         // setup the selector
         final String clientPropertiesFile = "jboss-ejb-client.properties";
         final InputStream inputStream = EJBClientReconnectionTestCase.class.getResourceAsStream(clientPropertiesFile);
@@ -191,10 +183,9 @@ public class EJBClientReconnectionTestCase {
         }
         final Properties properties = new Properties();
         properties.load(inputStream);
-        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
-        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
-
-        return EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using properties
+        return null;
     }
 
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
@@ -29,8 +29,14 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.manualmode.ejb.Util;
+import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientTransactionContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
 import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,6 +48,10 @@ import org.junit.runner.RunWith;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -55,7 +65,6 @@ import static org.junit.Assert.assertNotNull;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//TODO Elytron - ejb-client4 integration
 public class EJBClientReconnectionTestCase {
     private static final Logger log = Logger.getLogger(EJBClientReconnectionTestCase.class);
 
@@ -69,6 +78,8 @@ public class EJBClientReconnectionTestCase {
     private Deployer deployer;
 
     private Context context;
+    private ContextSelector<EJBClientContext> previousClientContextSelector;
+
 
     @Deployment(name = DEPLOYMENT, managed = false, testable = false)
     @TargetsContainer(CONTAINER)
@@ -80,6 +91,8 @@ public class EJBClientReconnectionTestCase {
     @Before
     public void before() throws Exception {
         this.context = Util.createNamingContext();
+        // setup the client context selector
+        this.previousClientContextSelector = setupEJBClientContextSelector();
 
         controller.start(CONTAINER);
         log.trace("===appserver started===");
@@ -89,6 +102,9 @@ public class EJBClientReconnectionTestCase {
 
     @After
     public void after() throws Exception {
+        if (this.previousClientContextSelector != null) {
+            EJBClientContext.setSelector(this.previousClientContextSelector);
+        }
         this.context.close();
 
         try {
@@ -123,6 +139,9 @@ public class EJBClientReconnectionTestCase {
 
     @Test
     public void testReconnectionWithClientAPI() throws Throwable {
+        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+
         final StatelessEJBLocator<SimpleCrashBeanRemote> locator = new StatelessEJBLocator(SimpleCrashBeanRemote.class, "", DEPLOYMENT, SimpleCrashBean.class.getSimpleName(), "");
         final SimpleCrashBeanRemote proxy = EJBClient.createProxy(locator);
 
@@ -155,4 +174,28 @@ public class EJBClientReconnectionTestCase {
 
         return remoteClass.cast(context.lookup(myContext));
     }
+
+    /**
+     * Sets up the EJB client context to use a selector which processes and sets up EJB receivers
+     * based on this testcase specific jboss-ejb-client.properties file
+     *
+     * @return
+     * @throws java.io.IOException
+     */
+    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+        // setup the selector
+        final String clientPropertiesFile = "jboss-ejb-client.properties";
+        final InputStream inputStream = EJBClientReconnectionTestCase.class.getResourceAsStream(clientPropertiesFile);
+        if (inputStream == null) {
+            throw new IllegalStateException("Could not find " + clientPropertiesFile + " in classpath");
+        }
+        final Properties properties = new Properties();
+        properties.load(inputStream);
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+
+        return EJBClientContext.setSelector(selector);
+    }
+
+
 }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
@@ -36,6 +36,11 @@ import org.jboss.as.test.manualmode.ejb.ssl.beans.StatefulBeanRemote;
 import org.jboss.as.test.manualmode.ejb.ssl.beans.StatelessBean;
 import org.jboss.as.test.manualmode.ejb.ssl.beans.StatelessBeanRemote;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -50,6 +55,8 @@ import org.junit.runner.RunWith;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
@@ -62,7 +69,6 @@ import java.util.concurrent.Future;
 @RunWith(Arquillian.class)
 @RunAsClient
 @Ignore("WFLY-1836")
-//TODO Elytron - ejb-client4 integration
 public class SSLEJBRemoteClientTestCase {
     private static final Logger log = Logger.getLogger(SSLEJBRemoteClientTestCase.class);
     private static final String MODULE_NAME_STATELESS = "ssl-remote-ejb-client-test";
@@ -70,6 +76,7 @@ public class SSLEJBRemoteClientTestCase {
     public static final String DEPLOYMENT_STATELESS = "dep_stateless";
     public static final String DEPLOYMENT_STATEFUL = "dep_stateful";
     private static boolean serverConfigDone = false;
+    private static ContextSelector<EJBClientContext> previousClientContextSelector;
 
     @ArquillianResource
     private static ContainerController container;
@@ -110,6 +117,24 @@ public class SSLEJBRemoteClientTestCase {
         System.setProperty("jboss.ejb.client.properties.skip.classloader.scan", "true");
     }
 
+    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+        log.trace("*** reading EJBClientContextSelector properties");
+        // setup the selector
+        final String clientPropertiesFile = "org/jboss/as/test/manualmode/ejb/ssl/jboss-ejb-client.properties";
+        final InputStream inputStream = SSLEJBRemoteClientTestCase.class.getClassLoader().getResourceAsStream(clientPropertiesFile);
+        if (inputStream == null) {
+            throw new IllegalStateException("Could not find " + clientPropertiesFile + " in classpath");
+        }
+        final Properties properties = new Properties();
+        properties.load(inputStream);
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
+        log.trace("*** creating EJBClientContextSelector");
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+        log.trace("*** applying EJBClientContextSelector");
+        return EJBClientContext.setSelector(selector);
+    }
+
+
     @Before
     public void prepareServerOnce() throws Exception {
         if(!serverConfigDone) {
@@ -128,6 +153,7 @@ public class SSLEJBRemoteClientTestCase {
             managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
             // write SSL realm config to output - debugging purposes
             SSLRealmSetupTool.readSSLRealmConfig(managementClient);
+            previousClientContextSelector = setupEJBClientContextSelector();
             serverConfigDone = true;
         } else {
             log.trace("*** Server already prepared, skipping config procedure");
@@ -136,6 +162,9 @@ public class SSLEJBRemoteClientTestCase {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        if (previousClientContextSelector != null) {
+            EJBClientContext.setSelector(previousClientContextSelector);
+        }
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
         SSLRealmSetupTool.tearDown(mClient, container);

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -34,10 +34,6 @@ import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
-import org.jboss.ejb.client.EJBClientConfiguration;
-import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -233,9 +229,8 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         config.put("remote.connection.default.host", managementClient.getWebUri().getHost());
         config.put("remote.connection.default.port", String.valueOf(managementClient.getWebUri().getPort()));
 
-        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(config);
-        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
-        EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using config
     }
 
 }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -34,6 +34,10 @@ import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -66,7 +70,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.DatabaseTimerServiceTestCaseServerSetup.class)
-//TODO Elytron - ejb-client4 integration
 public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
 
     public static final String ARCHIVE_NAME = "testTimerServiceSimple";
@@ -229,6 +232,10 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         config.put("remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS", "false");
         config.put("remote.connection.default.host", managementClient.getWebUri().getHost());
         config.put("remote.connection.default.port", String.valueOf(managementClient.getWebUri().getPort()));
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(config);
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+        EJBClientContext.setSelector(selector);
     }
 
 }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -34,6 +34,10 @@ import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -69,7 +73,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(DatabaseTimerServiceMultiNodeTestCase.DatabaseTimerServiceTestCaseServerSetup.class)
-//TODO Elytron - ejb-client4 integration
 public class DatabaseTimerServiceMultiNodeTestCase {
 
     public static final String ARCHIVE_NAME = "testTimerServiceSimple";
@@ -259,5 +262,9 @@ public class DatabaseTimerServiceMultiNodeTestCase {
         config.put("remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS", "false");
         config.put("remote.connection.default.host", managementClient.getWebUri().getHost());
         config.put("remote.connection.default.port", String.valueOf(managementClient.getWebUri().getPort()));
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(config);
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+        EJBClientContext.setSelector(selector);
     }
 }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -34,10 +34,6 @@ import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
-import org.jboss.ejb.client.EJBClientConfiguration;
-import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
-import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -263,8 +259,7 @@ public class DatabaseTimerServiceMultiNodeTestCase {
         config.put("remote.connection.default.host", managementClient.getWebUri().getHost());
         config.put("remote.connection.default.port", String.valueOf(managementClient.getWebUri().getPort()));
 
-        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(config);
-        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
-        EJBClientContext.setSelector(selector);
+        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
+        // that should be used for this test using config
     }
 }


### PR DESCRIPTION
Many tests have issues due to some test changes that were made as part of WFLY-5403 to get the basic integration testsuite to compile with the new EJB client API:
https://github.com/wildfly-security-incubator/wildfly/pull/44/commits/1df3c7aeac1a6b3d223237dbc759cc8f4328070f

Things like setting up client side interceptors, setting up the EJB client context, specifying particular EJB properties, etc. were just removed from these tests. This PR reverts those changes and where possible, adapts the tests to use the new EJB client API. TODOs have been added to tests for things that will need to be revisited/updated once the new transaction client changes and the new EJB client changes are in.
