### PR TITLE
[WFLY-8036] Register the deployments SecurityDomain with it's ClassLoader during deployment and clear during undeployment.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -23,6 +23,7 @@
 package org.wildfly.extension.undertow;
 
 import static io.undertow.util.StatusCodes.OK;
+import static java.security.AccessController.doPrivileged;
 import static org.wildfly.extension.undertow.logging.UndertowLogger.ROOT_LOGGER;
 import static org.wildfly.security.http.HttpConstants.CONFIG_CONTEXT_PATH;
 import static org.wildfly.security.http.HttpConstants.CONFIG_ERROR_PAGE;
@@ -31,6 +32,7 @@ import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -96,6 +98,7 @@ import org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler;
 import org.wildfly.elytron.web.undertow.server.ScopeSessionListener;
 import org.wildfly.extension.undertow.security.sso.DistributableApplicationSecurityDomainSingleSignOnManagerBuilder;
 import org.wildfly.security.auth.server.HttpAuthenticationFactory;
+import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpScope;
 import org.wildfly.security.http.HttpScopeNotification;
@@ -108,6 +111,7 @@ import org.wildfly.security.http.util.sso.SingleSignOnManager;
 import org.wildfly.security.http.util.sso.SingleSignOnServerMechanismFactory;
 import org.wildfly.security.http.util.sso.SingleSignOnServerMechanismFactory.SingleSignOnConfiguration;
 import org.wildfly.security.http.util.sso.SingleSignOnSessionFactory;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -354,6 +358,15 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
             final ScopeSessionListener scopeSessionListener = ScopeSessionListener.builder()
                     .addScopeResolver(Scope.APPLICATION, ApplicationSecurityDomainService::applicationScope)
                     .build();
+            if (WildFlySecurityManager.isChecking()) {
+                doPrivileged((PrivilegedAction<Void>) () -> {
+                    httpAuthenticationFactoryInjector.getValue().getSecurityDomain().registerWithClassLoader(deploymentInfo.getClassLoader());
+                    return null;
+                });
+            } else {
+                httpAuthenticationFactoryInjector.getValue().getSecurityDomain().registerWithClassLoader(deploymentInfo.getClassLoader());
+            }
+
             deploymentInfo.addSessionListener(scopeSessionListener);
 
             deploymentInfo.addInnerHandlerChainWrapper(this::finalSecurityHandlers);
@@ -660,6 +673,14 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
 
             @Override
             public void cancel() {
+                if (WildFlySecurityManager.isChecking()) {
+                    doPrivileged((PrivilegedAction<Void>) () -> {
+                        SecurityDomain.unregisterClassLoader(deploymentInfo.getClassLoader());
+                        return null;
+                    });
+                } else {
+                    SecurityDomain.unregisterClassLoader(deploymentInfo.getClassLoader());
+                }
                 synchronized(registrations) {
                     registrations.remove(this);
                 }


### PR DESCRIPTION
:boom: Don't merge until the Elytron change in https://github.com/wildfly-security/wildfly-elytron/pull/663 is accepted and merged but this is the WildFly side to associate the SecurityDomain with the ClassLoader of the Undertow deployment.
