### PR TITLE
[WFLY-7510] Unignore RemotingLoginModuleTestCase and RemotingLoginModuleUseNewClientCertTestCase and disable them instead

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java
@@ -82,11 +82,12 @@ import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
 import org.jboss.as.test.integration.security.common.ejb3.Hello;
 import org.jboss.as.test.integration.security.common.ejb3.HelloBean;
+import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.picketbox.util.KeyStoreUtil;
@@ -104,7 +105,6 @@ import org.picketbox.util.KeyStoreUtil;
         RemotingLoginModuleTestCase.SecurityDomainsSetup.class //
 })
 @RunAsClient
-@Ignore("WFLY-7510")
 public class RemotingLoginModuleTestCase {
     private static Logger LOGGER = Logger.getLogger(RemotingLoginModuleTestCase.class);
 
@@ -141,6 +141,11 @@ public class RemotingLoginModuleTestCase {
     private ManagementClient mgmtClient;
 
     // Public methods --------------------------------------------------------
+
+    @BeforeClass
+    public static void beforeClass() {
+        DisableInvocationTestUtil.disable();
+    }
 
     /**
      * Creates a deployment application for this test.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleUseNewClientCertTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleUseNewClientCertTestCase.java
@@ -44,11 +44,12 @@ import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
 import org.jboss.as.test.integration.security.common.ejb3.Hello;
 import org.jboss.as.test.integration.security.common.ejb3.HelloBean;
+import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.picketbox.util.KeyStoreUtil;
@@ -107,7 +108,6 @@ import static org.junit.Assert.fail;
         RemotingLoginModuleUseNewClientCertTestCase.SecurityDomainsSetup.class
 })
 @RunAsClient
-@Ignore("WFLY-7510")
 public class RemotingLoginModuleUseNewClientCertTestCase {
     private static Logger LOGGER = Logger.getLogger(RemotingLoginModuleUseNewClientCertTestCase.class);
 
@@ -141,6 +141,11 @@ public class RemotingLoginModuleUseNewClientCertTestCase {
     private ManagementClient mgmtClient;
 
     // Public methods --------------------------------------------------------
+
+    @BeforeClass
+    public static void beforeClass() {
+        DisableInvocationTestUtil.disable();
+    }
 
     /**
      * Creates a deployment application for this test.


### PR DESCRIPTION
Unignoring two test classes that had been temporarily ignored during the Remoting 5 integration phase and disabling them instead since they result in 4 failures. These tests involve certificate authentication.

https://issues.jboss.org/browse/WFLY-7510