### PR TITLE
[WFLY-8290] Use Elytron Subsystem from WildFly Core instead of independent artifact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,6 @@
         <version.org.wildfly.arquillian>2.1.0.Alpha1</version.org.wildfly.arquillian>
         <version.org.wildfly.http-client>1.0.0.Alpha3</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.0.Beta11</version.org.wildfly.naming-client>
-        <version.org.wildfly.security.elytron-subsystem>1.0.0.Beta11</version.org.wildfly.security.elytron-subsystem>
         <version.org.wildfly.transaction.client>1.0.0.Beta18</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.17</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11.jbossorg-1</version.sun.jaxb>
@@ -6248,12 +6247,6 @@
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-testenricher-msc</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.security</groupId>
-                <artifactId>elytron-subsystem</artifactId>
-                <version>${version.org.wildfly.security.elytron-subsystem}</version>
             </dependency>
 
             <dependency>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -54,8 +54,19 @@
             </exclusions>
         </dependency>
 
-		<!-- module and copy artifact dependencies -->
-		
+        <!-- module and copy artifact dependencies -->
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>
@@ -395,11 +406,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>elytron-subsystem</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -31,7 +31,7 @@
     </exports>
 
     <resources>
-        <artifact name="${org.wildfly.security:elytron-subsystem}"/>
+        <artifact name="${org.wildfly.core:wildfly-elytron}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
This pull request follows up on https://github.com/wildfly-security-incubator/wildfly-core/pull/51 - once the merge is in WildFly Core then this PR can follow.