### PR TITLE
tests for RA and datasource elytron integration

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/DsWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/DsWithElytronAuthContextTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 import org.wildfly.test.security.common.elytron.CredentialReference;
@@ -79,7 +78,7 @@ public class DsWithElytronAuthContextTestCase {
     @Deployment
     public static Archive<?> deployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar").addClasses(DsWithElytronAuthContextTestCase.class);
-        jar.addClasses(AbstractElytronSetupTask.class, ServerSetupTask.class);
+        jar.addClasses(AbstractElytronSetupTask.class);
         return ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(jar)
                 .addAsManifestResource(DsWithSecurityDomainTestCase.class.getPackage(), "security-ds-elytron.xml", "security-ds.xml");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/DsWithMixedSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/DsWithMixedSecurityTestCase.java
@@ -1,0 +1,251 @@
+/*
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.jboss.as.test.integration.jca.security;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.annotation.Resource;
+import javax.sql.DataSource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.MatchRules;
+import org.wildfly.test.security.common.elytron.SimpleAuthConfig;
+import org.wildfly.test.security.common.elytron.SimpleAuthContext;
+
+/**
+ * test multiple datasources, some uses elytron and some legacy security
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({DsWithMixedSecurityTestCase.ElytronSetup.class, DsWithMixedSecurityTestCase.DsWithSecurityDomainTestCaseSetup.class, DsWithMixedSecurityTestCase.SetupDatasources.class})
+public class DsWithMixedSecurityTestCase {
+
+    private static final String AUTH_CONTEXT = "MyAuthContext";
+    private static final String REALM = "DsRealm";
+    private static final String LEGACY_SECURITY_DATASOURCE_NAME = "LegacySecurityDatasource";
+    private static final String ELYTRON_SECURITY_DATASOURCE_NAME = "ElytronSecurityDatasource";
+    private static final String LEGACY_SECURITY_XADATASOURCE_NAME = "LegacySecurityXADatasource";
+    private static final String ELYTRON_SECURITY_XADATASOURCE_NAME = "ElytronSecurityXADatasource";
+
+    static class ElytronSetup extends AbstractElytronSetupTask {
+        private static final String AUTH_CONFIG = "MyAuthConfig";
+        private static final String DATABASE_USER = DsWithMixedSecurityTestCase.class.getName();
+        private static final String DATABASE_PASSWORD = "passWD12#$";
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            final CredentialReference credRefPwd = CredentialReference.builder().withClearText(DATABASE_PASSWORD).build();
+            final ConfigurableElement authenticationConfiguration = SimpleAuthConfig.builder().withName(AUTH_CONFIG)
+                    .withAuthenticationName(DATABASE_USER).withCredentialReference(credRefPwd).build();
+            final MatchRules matchRules = MatchRules.builder().withAuthenticationConfiguration(AUTH_CONFIG).build();
+            final ConfigurableElement authenticationContext = SimpleAuthContext.builder().withName(AUTH_CONTEXT).
+                    withMatchRules(matchRules).build();
+
+            return new ConfigurableElement[]{authenticationConfiguration, authenticationContext};
+        }
+    }
+
+    static class DsWithSecurityDomainTestCaseSetup extends AbstractLoginModuleSecurityDomainTestCaseSetup {
+
+        @Override
+        protected String getSecurityDomainName() {
+            return REALM;
+        }
+
+        @Override
+        protected String getLoginModuleName() {
+            return "ConfiguredIdentity";
+        }
+
+        @Override
+        protected boolean isRequired() {
+            return true;
+        }
+
+        @Override
+        protected Map<String, String> getModuleOptions() {
+            Map<String, String> moduleOptions = new HashMap<>();
+            moduleOptions.put("userName", DsWithMixedSecurityTestCase.class.getName());
+            moduleOptions.put("password", "passWD12#$");
+            moduleOptions.put("principal", DsWithMixedSecurityTestCase.class.getName());
+            return moduleOptions;
+        }
+    }
+
+    static class SetupDatasources implements ServerSetupTask {
+        private static final PathAddress DATASOURCES_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, "datasources");
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient mcc = managementClient.getControllerClient();
+            addDatasource(LEGACY_SECURITY_DATASOURCE_NAME, addOperation -> {
+                addOperation.get("security-domain").set(REALM);
+            }, mcc);
+            addDatasource(ELYTRON_SECURITY_DATASOURCE_NAME, addOperation -> {
+                addOperation.get("elytron-enabled").set("true");
+                addOperation.get("authentication-context").set(AUTH_CONTEXT);
+            }, mcc);
+            addXaDatasource(LEGACY_SECURITY_XADATASOURCE_NAME, addOperation -> {
+                addOperation.get("security-domain").set(REALM);
+            }, mcc);
+            addXaDatasource(ELYTRON_SECURITY_XADATASOURCE_NAME, addOperation -> {
+                addOperation.get("elytron-enabled").set("true");
+                addOperation.get("authentication-context").set(AUTH_CONTEXT);
+            }, mcc);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient mcc = managementClient.getControllerClient();
+            removeDatasourceSilently(LEGACY_SECURITY_DATASOURCE_NAME, mcc);
+            removeDatasourceSilently(ELYTRON_SECURITY_DATASOURCE_NAME, mcc);
+            removeXaDatasourceSilently(LEGACY_SECURITY_XADATASOURCE_NAME, mcc);
+            removeXaDatasourceSilently(ELYTRON_SECURITY_XADATASOURCE_NAME, mcc);
+        }
+
+        private void addDatasource(final String name, Consumer<ModelNode> configurationApplier, ModelControllerClient client) throws IOException {
+            PathAddress addr = DATASOURCES_ADDRESS.append("data-source", name);
+            final ModelNode addOperation = Operations.createAddOperation(addr.toModelNode());
+            addOperation.get("jndi-name").set("java:jboss/datasources/" + name);
+            addOperation.get("driver-name").set("h2");
+            addOperation.get("connection-url").set("jdbc:h2:mem:" + DsWithMixedSecurityTestCase.class.getName() + ";DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+            addOperation.get(OPERATION_HEADERS).get("allow-resource-service-restart").set(true);
+
+            configurationApplier.accept(addOperation);
+
+            ModelNode response = execute(addOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void addXaDatasource(final String name, Consumer<ModelNode> configurationApplier, ModelControllerClient client) throws IOException {
+            PathAddress addr = DATASOURCES_ADDRESS.append("xa-data-source", name);
+            final ModelNode addOperation = Operations.createAddOperation(addr.toModelNode());
+            addOperation.get("jndi-name").set("java:jboss/xa-datasources/" + name);
+            addOperation.get("driver-name").set("h2");
+            addOperation.get(OPERATION_HEADERS).get("allow-resource-service-restart").set(true);
+
+            configurationApplier.accept(addOperation);
+
+            final PathAddress urlXADatasourcePropertyAddress = addr.append("xa-datasource-properties", "URL");
+            final ModelNode addURLDatasourcePropertyOperation = Operations.createAddOperation(urlXADatasourcePropertyAddress.toModelNode());
+            addURLDatasourcePropertyOperation.get("value").set("jdbc:h2:mem:" + DsWithMixedSecurityTestCase.class.getName() + ";DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+
+            ModelNode compositeOperation = Operations.createCompositeOperation();
+            compositeOperation.get(ModelDescriptionConstants.STEPS).add(addOperation);
+            compositeOperation.get(ModelDescriptionConstants.STEPS).add(addURLDatasourcePropertyOperation);
+
+            ModelNode response = execute(compositeOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void removeDatasourceSilently(final String name, ModelControllerClient client) throws IOException {
+            PathAddress addr = DATASOURCES_ADDRESS.append("data-source", name);
+            ModelNode removeRaOperation = Operations.createRemoveOperation(addr.toModelNode());
+            removeRaOperation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set("true");
+            client.execute(removeRaOperation);
+        }
+
+        private void removeXaDatasourceSilently(final String name, ModelControllerClient client) throws IOException {
+            PathAddress addr = DATASOURCES_ADDRESS.append("xa-data-source", name);
+            ModelNode removeRaOperation = Operations.createRemoveOperation(addr.toModelNode());
+            removeRaOperation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set("true");
+            client.execute(removeRaOperation);
+        }
+
+        private ModelNode execute(ModelNode operation, ModelControllerClient client) throws IOException {
+            return client.execute(operation);
+        }
+    }
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar").addClasses(DsWithMixedSecurityTestCase.class);
+        jar.addClasses(AbstractElytronSetupTask.class, AbstractLoginModuleSecurityDomainTestCaseSetup.class, AbstractSecurityDomainSetup.class);
+        return ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(jar);
+    }
+
+    @Resource(mappedName = "java:jboss/datasources/" + LEGACY_SECURITY_DATASOURCE_NAME)
+    private DataSource legacySecurityDs;
+
+    @Resource(mappedName = "java:jboss/datasources/" + ELYTRON_SECURITY_DATASOURCE_NAME)
+    private DataSource elytronSecurityDs;
+
+    @Resource(mappedName = "java:jboss/xa-datasources/" + LEGACY_SECURITY_XADATASOURCE_NAME)
+    private DataSource legacySecurityXaDs;
+
+    @Resource(mappedName = "java:jboss/xa-datasources/" + ELYTRON_SECURITY_XADATASOURCE_NAME)
+    private DataSource elytronSecurityXaDs;
+
+    @Test
+    public void testLegacySecurityDatasource() throws Exception {
+        testDatasource(legacySecurityDs);
+    }
+
+    @Test
+    public void testElytronSecurityDatasource() throws Exception {
+        testDatasource(elytronSecurityDs);
+    }
+
+    @Test
+    public void testLegacySecurityXaDatasource() throws Exception {
+        testDatasource(legacySecurityXaDs);
+    }
+
+    @Test
+    public void testElytronSecurityXaDatasource() throws Exception {
+        testDatasource(elytronSecurityXaDs);
+    }
+
+    private void testDatasource(DataSource ds) throws Exception {
+        Assert.assertNotNull(ds);
+        try (Connection con = ds.getConnection()) {
+            assertNotNull(con);
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithElytronAuthContextTestCase.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 import org.wildfly.test.security.common.elytron.CredentialReference;
@@ -72,7 +71,7 @@ public class IronJacamarActivationRaWithElytronAuthContextTestCase {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar")
                 .addClass(IronJacamarActivationRaWithElytronAuthContextTestCase.class)
                 .addPackage(MultipleConnectionFactory1.class.getPackage());
-        jar.addClasses(AbstractElytronSetupTask.class, ServerSetupTask.class);
+        jar.addClasses(AbstractElytronSetupTask.class);
         final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "test.rar")
                 .addAsLibrary(jar)
                 .addAsManifestResource(IronJacamarActivationRaWithElytronAuthContextTestCase.class.getPackage(), "ra.xml", "ra.xml")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithElytronAuthContextTestCase.java
@@ -39,13 +39,13 @@ import org.wildfly.test.security.common.elytron.SimpleAuthConfig;
 import org.wildfly.test.security.common.elytron.SimpleAuthContext;
 
 /**
- * Test for RA with elytron security domain
+ * Test for RA with elytron security domain, RA is activated using bundled ironjacamar.xml
  *
  * @author Flavia Rainone
  */
 @RunWith(Arquillian.class)
-@ServerSetup(RaWithElytronAuthContextTestCase.ElytronSetup.class)
-public class RaWithElytronAuthContextTestCase {
+@ServerSetup(IronJacamarActivationRaWithElytronAuthContextTestCase.ElytronSetup.class)
+public class IronJacamarActivationRaWithElytronAuthContextTestCase {
 
     private static final String AUTH_CONFIG = "MyAuthConfig";
     private static final String AUTH_CONTEXT = "MyAuthContext";
@@ -70,13 +70,13 @@ public class RaWithElytronAuthContextTestCase {
     public static Archive<?> deploymentSingleton() {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar")
-                .addClass(RaWithElytronAuthContextTestCase.class)
+                .addClass(IronJacamarActivationRaWithElytronAuthContextTestCase.class)
                 .addPackage(MultipleConnectionFactory1.class.getPackage());
         jar.addClasses(AbstractElytronSetupTask.class, ServerSetupTask.class);
         final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "test.rar")
                 .addAsLibrary(jar)
-                .addAsManifestResource(RaWithElytronAuthContextTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(RaWithElytronAuthContextTestCase.class.getPackage(), "ironjacamar-elytron.xml",
+                .addAsManifestResource(IronJacamarActivationRaWithElytronAuthContextTestCase.class.getPackage(), "ra.xml", "ra.xml")
+                .addAsManifestResource(IronJacamarActivationRaWithElytronAuthContextTestCase.class.getPackage(), "ironjacamar-elytron.xml",
                         "ironjacamar.xml");
 
         return rar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithSecurityDomainTestCase.java
@@ -42,13 +42,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Test for RA with security domain JBQA-5953
+ * Test for RA with security domain JBQA-5953, RA is activated using bundled ironjacamar.xml
  *
  * @author <a href="mailto:vrastsel@redhat.com"> Vladimir Rastseluev</a>
  */
 @RunWith(Arquillian.class)
-@ServerSetup(RaWithSecurityDomainTestCase.RaWithSecurityDomainTestCaseSetup.class)
-public class RaWithSecurityDomainTestCase {
+@ServerSetup(IronJacamarActivationRaWithSecurityDomainTestCase.RaWithSecurityDomainTestCaseSetup.class)
+public class IronJacamarActivationRaWithSecurityDomainTestCase {
 
     static class RaWithSecurityDomainTestCaseSetup extends AbstractLoginModuleSecurityDomainTestCaseSetup {
 
@@ -80,12 +80,12 @@ public class RaWithSecurityDomainTestCase {
     @Deployment
     public static Archive<?> deploymentSingleton() {
 
-        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar").addClass(RaWithSecurityDomainTestCase.class)
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar").addClass(IronJacamarActivationRaWithSecurityDomainTestCase.class)
                 .addPackage(MultipleConnectionFactory1.class.getPackage());
         jar.addClasses(AbstractLoginModuleSecurityDomainTestCaseSetup.class, AbstractSecurityDomainSetup.class);
         final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "test.rar").addAsLibrary(jar)
-                .addAsManifestResource(RaWithSecurityDomainTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(RaWithSecurityDomainTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml");
+                .addAsManifestResource(IronJacamarActivationRaWithSecurityDomainTestCase.class.getPackage(), "ra.xml", "ra.xml")
+                .addAsManifestResource(IronJacamarActivationRaWithSecurityDomainTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml");
 
         return rar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
@@ -1,0 +1,162 @@
+/*
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jboss.as.test.integration.jca.security;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import javax.annotation.Resource;
+import javax.resource.cci.Connection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.MatchRules;
+import org.wildfly.test.security.common.elytron.SimpleAuthConfig;
+import org.wildfly.test.security.common.elytron.SimpleAuthContext;
+
+/**
+ * Test for RA with elytron security domain, RA is activated using resource-adapter subsystem
+ *
+ * @author Flavia Rainone
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({WildFlyActivationRaWithElytronAuthContextTestCase.ElytronSetup.class, WildFlyActivationRaWithElytronAuthContextTestCase.RaSetup.class})
+public class WildFlyActivationRaWithElytronAuthContextTestCase {
+
+    private static final String AUTH_CONFIG = "MyAuthConfig";
+    private static final String AUTH_CONTEXT = "MyAuthContext";
+    private static final String CREDENTIAL = "sa";
+    private static final String CONN_DEF_JNDI_NAME = "java:jboss/wf-ra-elytron-security";
+
+    static class ElytronSetup extends AbstractElytronSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            final CredentialReference credRefPwd = CredentialReference.builder().withClearText(CREDENTIAL).build();
+            final ConfigurableElement authenticationConfiguration = SimpleAuthConfig.builder().withName(AUTH_CONFIG)
+                    .withAuthenticationName(CREDENTIAL).withCredentialReference(credRefPwd).build();
+            final MatchRules matchRules = MatchRules.builder().withAuthenticationConfiguration(AUTH_CONFIG).build();
+            final ConfigurableElement authenticationContext = SimpleAuthContext.builder().withName(AUTH_CONTEXT).
+                    withMatchRules(matchRules).build();
+
+            return new ConfigurableElement[]{authenticationConfiguration, authenticationContext};
+        }
+    }
+
+    static class RaSetup implements ServerSetupTask {
+        private static final PathAddress RA_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, "resource-adapters")
+                .append("resource-adapter", "wf-ra-elytron-security");
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient mcc = managementClient.getControllerClient();
+            addResourceAdapter(mcc);
+            addConnectionDefinition(mcc);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            removeResourceAdapterSilently(managementClient.getControllerClient());
+        }
+
+        private void addResourceAdapter(ModelControllerClient client) throws IOException {
+            ModelNode addRaOperation = Operations.createAddOperation(RA_ADDRESS.toModelNode());
+            addRaOperation.get("archive").set("wf-ra-ely-security.rar");
+            addRaOperation.get("transaction-support").set("NoTransaction");
+            ModelNode response = execute(addRaOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void addConnectionDefinition(ModelControllerClient client) throws IOException {
+            PathAddress connectionDefinitionAddress = RA_ADDRESS.append("connection-definitions", "Pool1");
+            ModelNode addConnectionDefinitionOperation = Operations.createAddOperation(connectionDefinitionAddress.toModelNode());
+            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1");
+            addConnectionDefinitionOperation.get("jndi-name").set(CONN_DEF_JNDI_NAME);
+            addConnectionDefinitionOperation.get("elytron-enabled").set("true");
+            addConnectionDefinitionOperation.get("authentication-context").set(AUTH_CONTEXT);
+
+            ModelNode response = execute(addConnectionDefinitionOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void removeResourceAdapterSilently(ModelControllerClient client) throws IOException {
+            ModelNode removeRaOperation = Operations.createRemoveOperation(RA_ADDRESS.toModelNode());
+            removeRaOperation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set("true");
+            client.execute(removeRaOperation);
+        }
+
+        private ModelNode execute(ModelNode operation, ModelControllerClient client) throws IOException {
+            return client.execute(operation);
+        }
+    }
+
+    @Deployment
+    public static Archive<?> deploymentSingleton() {
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar")
+                .addClass(WildFlyActivationRaWithElytronAuthContextTestCase.class)
+                .addPackage(MultipleConnectionFactory1.class.getPackage());
+        jar.addClasses(AbstractElytronSetupTask.class, org.wildfly.core.testrunner.ServerSetupTask.class);
+        final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "wf-ra-ely-security.rar")
+                .addAsLibrary(jar)
+                .addAsManifestResource(WildFlyActivationRaWithElytronAuthContextTestCase.class.getPackage(), "ra.xml", "ra.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller, org.jboss.as.controller-client\n"), "MANIFEST.MF");
+
+        return rar;
+    }
+
+    @Resource(mappedName = CONN_DEF_JNDI_NAME)
+    private MultipleConnectionFactory1 connectionFactory1;
+
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Test
+    public void deploymentTest() throws Exception {
+        assertNotNull("CF1 not found", connectionFactory1);
+        Connection cci = connectionFactory1.getConnection();
+        assertNotNull("Cannot obtain connection", cci);
+        cci.close();
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
@@ -135,7 +135,7 @@ public class WildFlyActivationRaWithElytronAuthContextTestCase {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar")
                 .addClass(WildFlyActivationRaWithElytronAuthContextTestCase.class)
                 .addPackage(MultipleConnectionFactory1.class.getPackage());
-        jar.addClasses(AbstractElytronSetupTask.class, org.wildfly.core.testrunner.ServerSetupTask.class);
+        jar.addClasses(AbstractElytronSetupTask.class);
         final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "wf-ra-ely-security.rar")
                 .addAsLibrary(jar)
                 .addAsManifestResource(WildFlyActivationRaWithElytronAuthContextTestCase.class.getPackage(), "ra.xml", "ra.xml")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java
@@ -185,7 +185,7 @@ public class WildFlyActivationRaWithMixedSecurityTestCase {
     @Deployment(name = "ear", order = 2)
     public static Archive<?> deployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar");
-        jar.addClasses(AbstractElytronSetupTask.class, org.wildfly.core.testrunner.ServerSetupTask.class, WildFlyActivationRaWithMixedSecurityTestCase.class,
+        jar.addClasses(AbstractElytronSetupTask.class, WildFlyActivationRaWithMixedSecurityTestCase.class,
                 AbstractLoginModuleSecurityDomainTestCaseSetup.class, AbstractSecurityDomainSetup.class);
         return ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(jar)
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller, org.jboss.as.controller-client, deployment.wf-ra-ely-security.rar\n"), "MANIFEST.MF");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java
@@ -1,0 +1,218 @@
+/*
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.jboss.as.test.integration.jca.security;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import javax.annotation.Resource;
+import javax.resource.cci.Connection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.MatchRules;
+import org.wildfly.test.security.common.elytron.SimpleAuthConfig;
+import org.wildfly.test.security.common.elytron.SimpleAuthContext;
+
+/**
+ * test RA that has two connection definitions, one is using legacy security and second elytron
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({WildFlyActivationRaWithMixedSecurityTestCase.ElytronSetup.class, WildFlyActivationRaWithMixedSecurityTestCase.SecurityDomainSetup.class,
+        WildFlyActivationRaWithMixedSecurityTestCase.RaSetup.class})
+public class WildFlyActivationRaWithMixedSecurityTestCase {
+
+
+    private static final String AUTH_CONTEXT = "MyAuthContext";
+    private static final String LEGACY_SECURITY_CONN_DEF_JNDI_NAME = "java:jboss/wf-ra-security-domain";
+    private static final String ELYTRON_SECURITY_CONN_DEF_JNDI_NAME = "java:jboss/wf-ra-elytron-security";
+    private static final String SECURITY_REALM_NAME = "RaRealm";
+
+    static class ElytronSetup extends AbstractElytronSetupTask {
+        private static final String AUTH_CONFIG = "MyAuthConfig";
+        private static final String CREDENTIAL = "sa";
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            final CredentialReference credRefPwd = CredentialReference.builder().withClearText(CREDENTIAL).build();
+            final ConfigurableElement authenticationConfiguration = SimpleAuthConfig.builder().withName(AUTH_CONFIG)
+                    .withAuthenticationName(CREDENTIAL).withCredentialReference(credRefPwd).build();
+            final MatchRules matchRules = MatchRules.builder().withAuthenticationConfiguration(AUTH_CONFIG).build();
+            final ConfigurableElement authenticationContext = SimpleAuthContext.builder().withName(AUTH_CONTEXT).
+                    withMatchRules(matchRules).build();
+
+            return new ConfigurableElement[]{authenticationConfiguration, authenticationContext};
+        }
+    }
+
+    static class SecurityDomainSetup extends AbstractLoginModuleSecurityDomainTestCaseSetup {
+
+        @Override
+        protected String getSecurityDomainName() {
+            return SECURITY_REALM_NAME;
+        }
+
+        @Override
+        protected String getLoginModuleName() {
+            return "ConfiguredIdentity";
+        }
+
+        @Override
+        protected boolean isRequired() {
+            return true;
+        }
+
+        @Override
+        protected Map<String, String> getModuleOptions() {
+            Map<String, String> moduleOptions = new HashMap<>();
+            moduleOptions.put("userName", "sa");
+            moduleOptions.put("password", "sa");
+            moduleOptions.put("principal", "sa");
+            return moduleOptions;
+        }
+    }
+
+    static class RaSetup implements ServerSetupTask {
+        private static final PathAddress RA_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, "resource-adapters")
+                .append("resource-adapter", "wf-ra-elytron-security");
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient mcc = managementClient.getControllerClient();
+            addResourceAdapter(mcc);
+            addConnectionDefinition("pool1", ELYTRON_SECURITY_CONN_DEF_JNDI_NAME, addConnectionDefinitionOperation -> {
+                addConnectionDefinitionOperation.get("elytron-enabled").set("true");
+                addConnectionDefinitionOperation.get("authentication-context").set(AUTH_CONTEXT);
+            }, mcc);
+            addConnectionDefinition("pool2", LEGACY_SECURITY_CONN_DEF_JNDI_NAME, addConnectionDefinitionOperation -> {
+                addConnectionDefinitionOperation.get("security-domain").set(SECURITY_REALM_NAME);
+            }, mcc);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            removeResourceAdapterSilently(managementClient.getControllerClient());
+        }
+
+        private void addResourceAdapter(ModelControllerClient client) throws IOException {
+            ModelNode addRaOperation = Operations.createAddOperation(RA_ADDRESS.toModelNode());
+            addRaOperation.get("archive").set("wf-ra-ely-security.rar");
+            addRaOperation.get("transaction-support").set("NoTransaction");
+            ModelNode response = execute(addRaOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void addConnectionDefinition(String name, String jndiName, Consumer<ModelNode> attrProvider, ModelControllerClient client) throws IOException {
+            PathAddress connectionDefinitionAddress = RA_ADDRESS.append("connection-definitions", name);
+            ModelNode addConnectionDefinitionOperation = Operations.createAddOperation(connectionDefinitionAddress.toModelNode());
+            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1");
+            addConnectionDefinitionOperation.get("jndi-name").set(jndiName);
+
+            attrProvider.accept(addConnectionDefinitionOperation);
+
+            ModelNode response = execute(addConnectionDefinitionOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void removeResourceAdapterSilently(ModelControllerClient client) throws IOException {
+            ModelNode removeRaOperation = Operations.createRemoveOperation(RA_ADDRESS.toModelNode());
+            removeRaOperation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set("true");
+            client.execute(removeRaOperation);
+        }
+
+        private ModelNode execute(ModelNode operation, ModelControllerClient client) throws IOException {
+            return client.execute(operation);
+        }
+    }
+
+    @Deployment(name = "wf-ra-ely-security", testable = false, order = 1)
+    public static Archive<?> deployElytronRa() {
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar");
+        jar.addPackage(MultipleConnectionFactory1.class.getPackage());
+        final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "wf-ra-ely-security.rar")
+                .addAsLibrary(jar)
+                .addAsManifestResource(WildFlyActivationRaWithMixedSecurityTestCase.class.getPackage(), "ra.xml", "ra.xml");
+
+        return rar;
+    }
+
+    @Deployment(name = "ear", order = 2)
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar");
+        jar.addClasses(AbstractElytronSetupTask.class, org.wildfly.core.testrunner.ServerSetupTask.class, WildFlyActivationRaWithMixedSecurityTestCase.class,
+                AbstractLoginModuleSecurityDomainTestCaseSetup.class, AbstractSecurityDomainSetup.class);
+        return ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(jar)
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller, org.jboss.as.controller-client, deployment.wf-ra-ely-security.rar\n"), "MANIFEST.MF");
+    }
+
+    @Resource(mappedName = LEGACY_SECURITY_CONN_DEF_JNDI_NAME)
+    private MultipleConnectionFactory1 legacySecurityConnectionFactory;
+
+    @Resource(mappedName = ELYTRON_SECURITY_CONN_DEF_JNDI_NAME)
+    private MultipleConnectionFactory1 elytronSecurityConnectionFactory;
+
+    @Test
+    @OperateOnDeployment("ear")
+    public void testLegacySecurityConnectionFactory() throws Exception {
+        testConnectionFactory(legacySecurityConnectionFactory);
+    }
+
+    @Test
+    @OperateOnDeployment("ear")
+    public void testElytronSecurityConnectionFactory() throws Exception {
+        testConnectionFactory(elytronSecurityConnectionFactory);
+    }
+
+    public void testConnectionFactory(MultipleConnectionFactory1 mcf) throws Exception {
+        assertNotNull("CF not found", mcf);
+        Connection cci = mcf.getConnection();
+        assertNotNull("Cannot obtain connection", cci);
+        cci.close();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java
@@ -1,0 +1,155 @@
+/*
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.jboss.as.test.integration.jca.security;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Resource;
+import javax.resource.cci.Connection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for RA with security domain, RA is activated using resource-adapter subsystem
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({WildFlyActivationRaWithSecurityDomainTestCase.RaWithSecurityDomainTestCaseSetup.class, WildFlyActivationRaWithSecurityDomainTestCase.RaSetup.class})
+public class WildFlyActivationRaWithSecurityDomainTestCase {
+    private static final String CONN_DEF_JNDI_NAME = "java:jboss/wf-ra-security-domain";
+
+    static class RaWithSecurityDomainTestCaseSetup extends AbstractLoginModuleSecurityDomainTestCaseSetup {
+
+        @Override
+        protected String getSecurityDomainName() {
+            return "RaRealm";
+        }
+
+        @Override
+        protected String getLoginModuleName() {
+            return "ConfiguredIdentity";
+        }
+
+        @Override
+        protected boolean isRequired() {
+            return true;
+        }
+
+        @Override
+        protected Map<String, String> getModuleOptions() {
+            Map<String, String> moduleOptions = new HashMap<String, String>();
+            moduleOptions.put("userName", "sa");
+            moduleOptions.put("password", "sa");
+            moduleOptions.put("principal", "sa");
+            return moduleOptions;
+        }
+    }
+
+    static class RaSetup implements ServerSetupTask {
+        private static final PathAddress RA_ADDRESS = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, "resource-adapters")
+                .append("resource-adapter", "wf-ra-security-domain");
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient mcc = managementClient.getControllerClient();
+            addResourceAdapter(mcc);
+            addConnectionDefinition(mcc);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            removeResourceAdapterSilently(managementClient.getControllerClient());
+        }
+
+        private void addResourceAdapter(ModelControllerClient client) throws IOException {
+            ModelNode addRaOperation = Operations.createAddOperation(RA_ADDRESS.toModelNode());
+            addRaOperation.get("archive").set("wf-ra-security-domain.rar");
+            addRaOperation.get("transaction-support").set("NoTransaction");
+            ModelNode response = execute(addRaOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void addConnectionDefinition(ModelControllerClient client) throws IOException {
+            PathAddress connectionDefinitionAddress = RA_ADDRESS.append("connection-definitions", "Pool1");
+            ModelNode addConnectionDefinitionOperation = Operations.createAddOperation(connectionDefinitionAddress.toModelNode());
+            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1");
+            addConnectionDefinitionOperation.get("jndi-name").set(CONN_DEF_JNDI_NAME);
+            addConnectionDefinitionOperation.get("security-domain").set("RaRealm");
+
+            ModelNode response = execute(addConnectionDefinitionOperation, client);
+            Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        }
+
+        private void removeResourceAdapterSilently(ModelControllerClient client) throws IOException {
+            ModelNode removeRaOperation = Operations.createRemoveOperation(RA_ADDRESS.toModelNode());
+            removeRaOperation.get(ClientConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set("true");
+            client.execute(removeRaOperation);
+        }
+
+        private ModelNode execute(ModelNode operation, ModelControllerClient client) throws IOException {
+            return client.execute(operation);
+        }
+    }
+
+    @Deployment
+    public static Archive<?> deploymentSingleton() {
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "single.jar").addClass(WildFlyActivationRaWithSecurityDomainTestCase.class)
+                .addPackage(MultipleConnectionFactory1.class.getPackage());
+        jar.addClasses(AbstractLoginModuleSecurityDomainTestCaseSetup.class, AbstractSecurityDomainSetup.class);
+        final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "wf-ra-security-domain.rar").addAsLibrary(jar)
+                .addAsManifestResource(WildFlyActivationRaWithSecurityDomainTestCase.class.getPackage(), "ra.xml", "ra.xml");
+
+        return rar;
+    }
+
+    @Resource(mappedName = CONN_DEF_JNDI_NAME)
+    private MultipleConnectionFactory1 connectionFactory1;
+
+    @Test
+    public void deploymentTest() throws Exception {
+        assertNotNull("CF1 not found", connectionFactory1);
+        Connection cci = connectionFactory1.getConnection();
+        assertNotNull("Cannot obtain connection", cci);
+        cci.close();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/credentialreference/CredentialReferenceDatasourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/credentialreference/CredentialReferenceDatasourceTestCase.java
@@ -185,7 +185,7 @@ public class CredentialReferenceDatasourceTestCase {
         addOperation.get("jndi-name").set(scenario.getDatasourceJndiName());
         addOperation.get("driver-name").set("h2");
         addOperation.get("user-name").set("sa");
-        addOperation.get("connection-url").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(client) + "/mem:test");
+        addOperation.get("connection-url").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(client) + "/mem:" + CredentialReferenceDatasourceTestCase.class.getName());
         addOperation.get(ModelDescriptionConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(true);
 
         ModelNode credentialReference = null;
@@ -245,7 +245,7 @@ public class CredentialReferenceDatasourceTestCase {
 
         final PathAddress urlXADatasourcePropertyAddress = scenario.getXADatasourceAddress().append("xa-datasource-properties", "URL");
         final ModelNode addURLDatasourcePropertyOperation = Operations.createAddOperation(urlXADatasourcePropertyAddress.toModelNode());
-        addURLDatasourcePropertyOperation.get("value").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(client) + "/mem:test");
+        addURLDatasourcePropertyOperation.get("value").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(client) + "/mem:" + CredentialReferenceDatasourceTestCase.class.getName());
 
         ModelNode compositeOperation = Operations.createCompositeOperation();
         compositeOperation.get(ModelDescriptionConstants.STEPS).add(addOperation);
@@ -281,7 +281,7 @@ public class CredentialReferenceDatasourceTestCase {
         public void setup(ManagementClient managementClient, String s) throws Exception {
             h2Server = Server.createTcpServer("-tcpAllowOthers").start();
             // open connection to database, because that's only (easy) way to set password for user sa
-            connection = DriverManager.getConnection("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", "sa", DATABASE_PASSWORD);
+            connection = DriverManager.getConnection("jdbc:h2:mem:" + CredentialReferenceDatasourceTestCase.class.getName() + ";DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", "sa", DATABASE_PASSWORD);
         }
 
         @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/vault/VaultDatasourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/vault/VaultDatasourceTestCase.java
@@ -94,7 +94,7 @@ public class VaultDatasourceTestCase {
             server = Server.createTcpServer("-tcpAllowOthers").start();
 
             Class.forName("org.h2.Driver");
-            connection = DriverManager.getConnection("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", "sa", RIGHT_PASSWORD);
+            connection = DriverManager.getConnection("jdbc:h2:mem:" + VaultDatasourceTestCase.class.getName() +";DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", "sa", RIGHT_PASSWORD);
             executeUpdate(connection, "CREATE TABLE TestPeople(Name Varchar(50), Surname Varchar(50))");
             executeUpdate(connection, "INSERT INTO TestPeople VALUES ('John','Smith')");
             // create new vault
@@ -134,7 +134,7 @@ public class VaultDatasourceTestCase {
             op.get(OP_ADDR).set(address);
             op.get("jndi-name").set("java:jboss/datasources/" + VAULT_BLOCK);
             op.get("driver-name").set("h2");
-            op.get("connection-url").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(managementClient) + "/mem:test");
+            op.get("connection-url").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(managementClient) + "/mem:" + VaultDatasourceTestCase.class.getName());
             op.get("user-name").set("sa");
             op.get("password").set("${" + vaultPasswordString + "}");
             op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
@@ -152,7 +152,7 @@ public class VaultDatasourceTestCase {
             op.get(OP_ADDR).set(address);
             op.get("jndi-name").set("java:jboss/datasources/" + VAULT_BLOCK_WRONG);
             op.get("driver-name").set("h2");
-            op.get("connection-url").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(managementClient) + "/mem:test");
+            op.get("connection-url").set("jdbc:h2:tcp://" + Utils.getSecondaryTestAddress(managementClient) + "/mem:" + VaultDatasourceTestCase.class.getName());
             op.get("user-name").set("sa");
             op.get("password").set("${" + wrongVaultPasswordString + "}");
             op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
@@ -210,7 +210,7 @@ public class VaultDatasourceTestCase {
             + "security/ds-vault/";
     static final String VAULT_BLOCK = "ds_TestDS";
     static final String VAULT_BLOCK_WRONG = VAULT_BLOCK + "Wrong";
-    static final String RIGHT_PASSWORD = "chucknorris";
+    static final String RIGHT_PASSWORD = "PasswordForVault";
     static final String WRONG_PASSWORD = "wrongPasswordForVault";
 
     /*


### PR DESCRIPTION
extented tests for RA and datasource elytron integration
* added/extended tests for RA with ironjacamar.xml and wf management configuration (both legacy and elytron)
* added test for multiple (xa)datasource where some uses legacy security and some elytron
* added test for RA with two connection definitions where one uses legacy security and and second uses elytron

https://issues.jboss.org/browse/WFLY-6400
https://issues.jboss.org/browse/WFLY-8010