### PR TITLE
[WFLY-8320] Update more clustering tests to set the EJB client properties using JBossEJBProperties.runCallable() instead of using the context selector approach

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -6,7 +6,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopology;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetriever;
@@ -15,6 +14,7 @@ import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
+import org.jboss.ejb.client.legacy.JBossEJBProperties;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -54,55 +54,53 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
 
     @Test
     public void test() throws Exception {
+        JBossEJBProperties properites = JBossEJBProperties.fromClassPath(CommandDispatcherTestCase.class.getClassLoader(), CLIENT_PROPERTIES);
+        properites.runCallable(() -> {
+            try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+                ClusterTopologyRetriever bean = directory.lookupStateless(ClusterTopologyRetrieverBean.class, ClusterTopologyRetriever.class);
+                ClusterTopology topology = bean.getClusterTopology();
+                assertEquals(2, topology.getNodes().size());
+                assertTrue(topology.getNodes().toString(), topology.getNodes().contains(NODE_1));
+                assertTrue(topology.getNodes().toString(), topology.getNodes().contains(NODE_2));
+                assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
 
-        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
-        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
-        // to its original state at the end of the test
-        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+                undeploy(DEPLOYMENT_2);
 
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
-            ClusterTopologyRetriever bean = directory.lookupStateless(ClusterTopologyRetrieverBean.class, ClusterTopologyRetriever.class);
-            ClusterTopology topology = bean.getClusterTopology();
-            assertEquals(2, topology.getNodes().size());
-            assertTrue(topology.getNodes().toString(), topology.getNodes().contains(NODE_1));
-            assertTrue(topology.getNodes().toString(), topology.getNodes().contains(NODE_2));
-            assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
+                topology = bean.getClusterTopology();
+                assertEquals(1, topology.getNodes().size());
+                assertTrue(topology.getNodes().contains(NODE_1));
+                assertEquals(NODE_1, topology.getLocalNode());
+                assertTrue(topology.getRemoteNodes().toString(), topology.getRemoteNodes().isEmpty());
 
-            undeploy(DEPLOYMENT_2);
+                deploy(DEPLOYMENT_2);
 
-            topology = bean.getClusterTopology();
-            assertEquals(1, topology.getNodes().size());
-            assertTrue(topology.getNodes().contains(NODE_1));
-            assertEquals(NODE_1, topology.getLocalNode());
-            assertTrue(topology.getRemoteNodes().toString(), topology.getRemoteNodes().isEmpty());
+                Thread.sleep(VIEW_CHANGE_WAIT);
 
-            deploy(DEPLOYMENT_2);
+                topology = bean.getClusterTopology();
+                assertEquals(2, topology.getNodes().size());
+                assertTrue(topology.getNodes().contains(NODE_1));
+                assertTrue(topology.getNodes().contains(NODE_2));
+                assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
 
-            Thread.sleep(VIEW_CHANGE_WAIT);
+                stop(CONTAINER_1);
 
-            topology = bean.getClusterTopology();
-            assertEquals(2, topology.getNodes().size());
-            assertTrue(topology.getNodes().contains(NODE_1));
-            assertTrue(topology.getNodes().contains(NODE_2));
-            assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
+                topology = bean.getClusterTopology();
+                assertEquals(1, topology.getNodes().size());
+                assertTrue(topology.getNodes().contains(NODE_2));
+                assertEquals(NODE_2, topology.getLocalNode());
+                assertTrue(topology.getRemoteNodes().toString(), topology.getRemoteNodes().isEmpty());
 
-            stop(CONTAINER_1);
+                start(CONTAINER_1);
 
-            topology = bean.getClusterTopology();
-            assertEquals(1, topology.getNodes().size());
-            assertTrue(topology.getNodes().contains(NODE_2));
-            assertEquals(NODE_2, topology.getLocalNode());
-            assertTrue(topology.getRemoteNodes().toString(), topology.getRemoteNodes().isEmpty());
+                Thread.sleep(VIEW_CHANGE_WAIT);
 
-            start(CONTAINER_1);
-
-            Thread.sleep(VIEW_CHANGE_WAIT);
-
-            topology = bean.getClusterTopology();
-            assertEquals(topology.getNodes().toString(), 2, topology.getNodes().size());
-            assertTrue(topology.getNodes().toString() + " should contain " + NODE_1, topology.getNodes().contains(NODE_1));
-            assertTrue(topology.getNodes().toString() + " should contain " + NODE_2, topology.getNodes().contains(NODE_2));
-            assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
-        }
+                topology = bean.getClusterTopology();
+                assertEquals(topology.getNodes().toString(), 2, topology.getNodes().size());
+                assertTrue(topology.getNodes().toString() + " should contain " + NODE_1, topology.getNodes().contains(NODE_1));
+                assertTrue(topology.getNodes().toString() + " should contain " + NODE_2, topology.getNodes().contains(NODE_2));
+                assertFalse(topology.getRemoteNodes().toString() + " should not contain " + topology.getLocalNode(), topology.getRemoteNodes().contains(topology.getLocalNode()));
+            }
+            return null;
+        });
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -45,7 +45,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
-import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.InfinispanExceptionThrowingIncrementorBean;
@@ -58,6 +57,7 @@ import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
+import org.jboss.ejb.client.legacy.JBossEJBProperties;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -124,171 +124,171 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     private void testStatelessFailover(String properties, Class<? extends Incrementor> beanClass) throws Exception {
-        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
-        // that should be used for this test using properties and ensure the EJB client context is reset
-        // to its original state at the end of the test
-        EJBClientContextSelector.setup(properties);
-        try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
-            Incrementor bean = context.lookupStateless(beanClass, Incrementor.class);
+        JBossEJBProperties ejbProperties = JBossEJBProperties.fromClassPath(RemoteFailoverTestCase.class.getClassLoader(), properties);
+        ejbProperties.runCallable(() -> {
+            try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
+                Incrementor bean = context.lookupStateless(beanClass, Incrementor.class);
 
-            // Allow sufficient time for client to receive full topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+                // Allow sufficient time for client to receive full topology
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
 
-            List<String> results = new ArrayList<>(COUNT);
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.add(result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
+                List<String> results = new ArrayList<>(COUNT);
+                for (int i = 0; i < COUNT; ++i) {
+                    Result<Integer> result = bean.increment();
+                    results.add(result.getNode());
+                    Thread.sleep(INVOCATION_WAIT);
+                }
+
+                for (String node : NODES) {
+                    int frequency = Collections.frequency(results, node);
+                    assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
+                }
+
+                undeploy(DEPLOYMENT_1);
+
+                for (int i = 0; i < COUNT; ++i) {
+                    Result<Integer> result = bean.increment();
+                    results.set(i, result.getNode());
+                    Thread.sleep(INVOCATION_WAIT);
+                }
+
+                Assert.assertEquals(0, Collections.frequency(results, NODE_1));
+                Assert.assertEquals(COUNT, Collections.frequency(results, NODE_2));
+
+                deploy(DEPLOYMENT_1);
+
+                // Allow sufficient time for client to receive new topology
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+                for (int i = 0; i < COUNT; ++i) {
+                    Result<Integer> result = bean.increment();
+                    results.set(i, result.getNode());
+                    Thread.sleep(INVOCATION_WAIT);
+                }
+
+                for (String node : NODES) {
+                    int frequency = Collections.frequency(results, node);
+                    assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
+                }
+
+                stop(CONTAINER_2);
+
+                for (int i = 0; i < COUNT; ++i) {
+                    Result<Integer> result = bean.increment();
+                    results.set(i, result.getNode());
+                    Thread.sleep(INVOCATION_WAIT);
+                }
+
+                Assert.assertEquals(COUNT, Collections.frequency(results, NODE_1));
+                Assert.assertEquals(0, Collections.frequency(results, NODE_2));
+
+                start(CONTAINER_2);
+
+                // Allow sufficient time for client to receive new topology
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+                for (int i = 0; i < COUNT; ++i) {
+                    Result<Integer> result = bean.increment();
+                    results.set(i, result.getNode());
+                    Thread.sleep(INVOCATION_WAIT);
+                }
+
+                for (String node : NODES) {
+                    int frequency = Collections.frequency(results, node);
+                    assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
+                }
             }
-
-            for (String node: NODES) {
-                int frequency = Collections.frequency(results, node);
-                assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
-            }
-
-            undeploy(DEPLOYMENT_1);
-
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
-            }
-
-            Assert.assertEquals(0, Collections.frequency(results, NODE_1));
-            Assert.assertEquals(COUNT, Collections.frequency(results, NODE_2));
-
-            deploy(DEPLOYMENT_1);
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
-            }
-
-            for (String node: NODES) {
-                int frequency = Collections.frequency(results, node);
-                assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
-            }
-
-            stop(CONTAINER_2);
-
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
-            }
-
-            Assert.assertEquals(COUNT, Collections.frequency(results, NODE_1));
-            Assert.assertEquals(0, Collections.frequency(results, NODE_2));
-
-            start(CONTAINER_2);
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            for (int i = 0; i < COUNT; ++i) {
-                Result<Integer> result = bean.increment();
-                results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
-            }
-
-            for (String node: NODES) {
-                int frequency = Collections.frequency(results, node);
-                assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
-            }
-        }
+            return null;
+        });
     }
 
     @InSequence(2)
     @Test
     public void testStatefulFailover() throws Exception {
-        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
-        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
-        // to its original state at the end of the test
-        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
-        try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
-            Incrementor bean = context.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
+        JBossEJBProperties properties = JBossEJBProperties.fromClassPath(RemoteFailoverTestCase.class.getClassLoader(), CLIENT_PROPERTIES);
+        properties.runCallable(() -> {
+            try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
+                Incrementor bean = context.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 
-            Result<Integer> result = bean.increment();
-            String target = result.getNode();
-            int count = 1;
+                Result<Integer> result = bean.increment();
+                String target = result.getNode();
+                int count = 1;
 
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
-                result = bean.increment();
                 Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
 
-            undeploy(this.findDeployment(target));
+                // Bean should retain weak affinity for this node
+                for (int i = 0; i < COUNT; ++i) {
+                    result = bean.increment();
+                    Assert.assertEquals(count++, result.getValue().intValue());
+                    Assert.assertEquals(String.valueOf(i), target, result.getNode());
+                }
 
-            result = bean.increment();
-            // Bean should failover to other node
-            String failoverTarget = result.getNode();
+                undeploy(this.findDeployment(target));
 
-            Assert.assertEquals(count++, result.getValue().intValue());
-            Assert.assertNotEquals(target, failoverTarget);
-
-            deploy(this.findDeployment(target));
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            result = bean.increment();
-            String failbackTarget = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-            // Bean should retain weak affinity for this node
-            Assert.assertEquals(failoverTarget, failbackTarget);
-
-            result = bean.increment();
-            // Bean may have acquired new weak affinity
-            target = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
                 result = bean.increment();
+                // Bean should failover to other node
+                String failoverTarget = result.getNode();
+
                 Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
+                Assert.assertNotEquals(target, failoverTarget);
 
-            stop(this.findContainer(target));
+                deploy(this.findDeployment(target));
 
-            result = bean.increment();
-            // Bean should failover to other node
-            failoverTarget = result.getNode();
+                // Allow sufficient time for client to receive new topology
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
 
-            Assert.assertEquals(count++, result.getValue().intValue());
-            Assert.assertNotEquals(target, failoverTarget);
-
-            start(this.findContainer(target));
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            result = bean.increment();
-            failbackTarget = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-            // Bean should retain weak affinity for this node
-            Assert.assertEquals(failoverTarget, failbackTarget);
-
-            result = bean.increment();
-            // Bean may have acquired new weak affinity
-            target = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
                 result = bean.increment();
+                String failbackTarget = result.getNode();
                 Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+                // Bean should retain weak affinity for this node
+                Assert.assertEquals(failoverTarget, failbackTarget);
+
+                result = bean.increment();
+                // Bean may have acquired new weak affinity
+                target = result.getNode();
+                Assert.assertEquals(count++, result.getValue().intValue());
+
+                // Bean should retain weak affinity for this node
+                for (int i = 0; i < COUNT; ++i) {
+                    result = bean.increment();
+                    Assert.assertEquals(count++, result.getValue().intValue());
+                    Assert.assertEquals(String.valueOf(i), target, result.getNode());
+                }
+
+                stop(this.findContainer(target));
+
+                result = bean.increment();
+                // Bean should failover to other node
+                failoverTarget = result.getNode();
+
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertNotEquals(target, failoverTarget);
+
+                start(this.findContainer(target));
+
+                // Allow sufficient time for client to receive new topology
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+                result = bean.increment();
+                failbackTarget = result.getNode();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                // Bean should retain weak affinity for this node
+                Assert.assertEquals(failoverTarget, failbackTarget);
+
+                result = bean.increment();
+                // Bean may have acquired new weak affinity
+                target = result.getNode();
+                Assert.assertEquals(count++, result.getValue().intValue());
+
+                // Bean should retain weak affinity for this node
+                for (int i = 0; i < COUNT; ++i) {
+                    result = bean.increment();
+                    Assert.assertEquals(count++, result.getValue().intValue());
+                    Assert.assertEquals(String.valueOf(i), target, result.getNode());
+                }
             }
-        }
+            return null;
+        });
     }
 
     @Test
@@ -303,54 +303,54 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     public void testConcurrentFailover(Lifecycle lifecycle) throws Exception {
-        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
-        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
-        // to its original state at the end of the test
-        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
-            Incrementor bean = directory.lookupStateful(SlowToDestroyStatefulIncrementorBean.class, Incrementor.class);
-            AtomicInteger count = new AtomicInteger();
+        JBossEJBProperties properties = JBossEJBProperties.fromClassPath(RemoteFailoverTestCase.class.getClassLoader(), CLIENT_PROPERTIES);
+        properties.runCallable(() -> {
+            try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+                Incrementor bean = directory.lookupStateful(SlowToDestroyStatefulIncrementorBean.class, Incrementor.class);
+                AtomicInteger count = new AtomicInteger();
 
-            // Allow sufficient time for client to receive full topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+                // Allow sufficient time for client to receive full topology
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
 
-            String target = bean.increment().getNode();
-            count.incrementAndGet();
-            ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-            try {
-                CountDownLatch latch = new CountDownLatch(1);
-                Future<?> future = executor.scheduleWithFixedDelay(new IncrementTask(bean, count, latch), 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
-                latch.await();
-
-                lifecycle.stop(target);
-
-                future.cancel(false);
+                String target = bean.increment().getNode();
+                count.incrementAndGet();
+                ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
                 try {
-                    future.get();
-                } catch (CancellationException e) {
-                    // Ignore
+                    CountDownLatch latch = new CountDownLatch(1);
+                    Future<?> future = executor.scheduleWithFixedDelay(new IncrementTask(bean, count, latch), 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
+                    latch.await();
+
+                    lifecycle.stop(target);
+
+                    future.cancel(false);
+                    try {
+                        future.get();
+                    } catch (CancellationException e) {
+                        // Ignore
+                    }
+
+                    lifecycle.start(target);
+
+                    latch = new CountDownLatch(1);
+                    future = executor.scheduleWithFixedDelay(new LookupTask(directory, SlowToDestroyStatefulIncrementorBean.class, latch), 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
+                    latch.await();
+
+                    lifecycle.stop(target);
+
+                    future.cancel(false);
+                    try {
+                        future.get();
+                    } catch (CancellationException e) {
+                        // Ignore
+                    }
+
+                    lifecycle.start(target);
+                } finally {
+                    executor.shutdownNow();
                 }
-
-                lifecycle.start(target);
-
-                latch = new CountDownLatch(1);
-                future = executor.scheduleWithFixedDelay(new LookupTask(directory, SlowToDestroyStatefulIncrementorBean.class, latch), 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
-                latch.await();
-
-                lifecycle.stop(target);
-
-                future.cancel(false);
-                try {
-                    future.get();
-                } catch (CancellationException e) {
-                    // Ignore
-                }
-
-                lifecycle.start(target);
-            } finally {
-                executor.shutdownNow();
             }
-        }
+            return null;
+        });
     }
 
     /**
@@ -359,20 +359,20 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     @InSequence(5)
     @Test
     public void testClientException() throws Exception {
-        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
-        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
-        // to its original state at the end of the test
-        EJBClientContextSelector.setup(CLIENT_PROPERTIES);
-        try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
-            Incrementor bean = context.lookupStateful(InfinispanExceptionThrowingIncrementorBean.class, Incrementor.class);
+        JBossEJBProperties properties = JBossEJBProperties.fromClassPath(RemoteFailoverTestCase.class.getClassLoader(), CLIENT_PROPERTIES);
+        properties.runCallable(() -> {
+            try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
+                Incrementor bean = context.lookupStateful(InfinispanExceptionThrowingIncrementorBean.class, Incrementor.class);
 
-            bean.increment();
-        } catch (Exception ejbException) {
-            assertTrue("Expected exception wrapped in EJBException", ejbException instanceof EJBException);
-            assertNull("Cause of EJBException has not been removed", ejbException.getCause());
-            return;
-        }
-        fail("Expected EJBException but didn't catch it");
+                bean.increment();
+            } catch (Exception ejbException) {
+                assertTrue("Expected exception wrapped in EJBException", ejbException instanceof EJBException);
+                assertNull("Cause of EJBException has not been removed", ejbException.getCause());
+                return null;
+            }
+            fail("Expected EJBException but didn't catch it");
+            return null;
+        });
     }
 
     private class IncrementTask implements Runnable {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -9,13 +9,13 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriever;
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
+import org.jboss.ejb.client.legacy.JBossEJBProperties;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -54,43 +54,42 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
 
     @Test
     public void test() throws Exception {
-        // TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
-        // that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
-        // to its original state at the end of the test
-       EJBClientContextSelector.setup(CLIENT_PROPERTIES);
+        JBossEJBProperties properties = JBossEJBProperties.fromClassPath(ServiceProviderRegistrationTestCase.class.getClassLoader(), CLIENT_PROPERTIES);
+        properties.runCallable(() -> {
+            try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+                ServiceProviderRetriever bean = directory.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
+                Collection<String> names = bean.getProviders();
+                assertEquals(2, names.size());
+                assertTrue(names.toString(), names.contains(NODE_1));
+                assertTrue(names.toString(), names.contains(NODE_2));
 
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
-            ServiceProviderRetriever bean = directory.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
-            Collection<String> names = bean.getProviders();
-            assertEquals(2, names.size());
-            assertTrue(names.toString(), names.contains(NODE_1));
-            assertTrue(names.toString(), names.contains(NODE_2));
+                undeploy(DEPLOYMENT_1);
 
-            undeploy(DEPLOYMENT_1);
+                names = bean.getProviders();
+                assertEquals(1, names.size());
+                assertTrue(names.contains(NODE_2));
 
-            names = bean.getProviders();
-            assertEquals(1, names.size());
-            assertTrue(names.contains(NODE_2));
+                deploy(DEPLOYMENT_1);
 
-            deploy(DEPLOYMENT_1);
+                names = bean.getProviders();
+                assertEquals(2, names.size());
+                assertTrue(names.contains(NODE_1));
+                assertTrue(names.contains(NODE_2));
 
-            names = bean.getProviders();
-            assertEquals(2, names.size());
-            assertTrue(names.contains(NODE_1));
-            assertTrue(names.contains(NODE_2));
+                stop(CONTAINER_2);
 
-            stop(CONTAINER_2);
+                names = bean.getProviders();
+                assertEquals(1, names.size());
+                assertTrue(names.contains(NODE_1));
 
-            names = bean.getProviders();
-            assertEquals(1, names.size());
-            assertTrue(names.contains(NODE_1));
+                start(CONTAINER_2);
 
-            start(CONTAINER_2);
-
-            names = bean.getProviders();
-            assertEquals(2, names.size());
-            assertTrue(names.contains(NODE_1));
-            assertTrue(names.contains(NODE_2));
-        }
+                names = bean.getProviders();
+                assertEquals(2, names.size());
+                assertTrue(names.contains(NODE_1));
+                assertTrue(names.contains(NODE_2));
+            }
+            return null;
+        });
     }
 }


### PR DESCRIPTION
Once wildfly-discovery and jboss-ejb-client have been released, this will fix 5 of the remaining 8 clustering failures.
