### PR TITLE
[WFLY-8382] Elytron - exported capabilities interfaces

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -27,7 +27,7 @@
     <exports>
         <exclude path="org/wildfly/extension/elytron/ElytronExtension"/>
         <exclude path="org/wildfly/extension/elytron/_private"/>
-        <exclude path="org/wildfly/extension/elytron/capabilities"/>
+        <exclude path="org/wildfly/extension/elytron/capabilities/_private"/>
     </exports>
 
     <resources>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8382
**Requires:** https://github.com/wildfly-security-incubator/wildfly-core/pull/78

As discussed, required interfaces will be exported.
~~But cannot export required interfaces only - current filter allows only package-based filtering - whole capabilities package will be exported.~~