### PR TITLE
[WFCORE-2560]: User names in Elytron FileSystemRealm are not case sensitive on Windows.

### DIFF
--- a/testsuite/elytron/modify-elytron-config.cli
+++ b/testsuite/elytron/modify-elytron-config.cli
@@ -31,8 +31,8 @@ embed-server --jboss-home=${jboss.home.dir} --admin-only=true
 
 # add test users (copies the test configuration from property files)
 
-/subsystem=elytron/filesystem-realm=ManagementFsRealm/identity=testSuite:add()
-/subsystem=elytron/filesystem-realm=ManagementFsRealm/identity=testSuite:set-password(clear={password="testSuitePassword"})
+/subsystem=elytron/filesystem-realm=ManagementFsRealm/identity=testsuite:add()
+/subsystem=elytron/filesystem-realm=ManagementFsRealm/identity=testsuite:set-password(clear={password="testSuitePassword"})
 
 /subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user1:add()
 /subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user1:set-password(clear={password="password1"})


### PR DESCRIPTION
Updating script for lower case principals.

Jira: https://issues.jboss.org/browse/WFCORE-2560
JBEAP: https://issues.jboss.org/browse/JBEAP-8810
Core PR: https://github.com/wildfly-security-incubator/wildfly-core/pull/87