### PR TITLE
[WFCORE-2455]: Empty  secret-value is not allowed in credential stores

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/AbstractCredentialStoreTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/AbstractCredentialStoreTestCase.java
@@ -129,17 +129,22 @@ public abstract class AbstractCredentialStoreTestCase {
 
     /**
      * Creates alias in given credential store (must exist) with provided secret value. Then uses
-     * {@link #assertCredentialValue(String, String, String)} method to check if it's correctly stored in the credential store.
-     * It removes the alias as the final step.
+     * {@link #assertCredentialValue(String, String, String)} method to check if it's correctly stored in the credential
+     * store. It removes the alias as the final step.
      */
     protected void assertAliasAndSecretSupported(String storeName, String alias, String secret) throws Exception {
         try (CLIWrapper cli = new CLIWrapper(true)) {
             try {
-                cli.sendLine(String.format("/subsystem=elytron/credential-store=%s/alias=%s:add(secret-value=\"%s\"", storeName,
-                        alias, secret));
-                assertCredentialValue(storeName, alias, secret);
+                if (secret != null) {
+                    cli.sendLine(String.format("/subsystem=elytron/credential-store=%s/alias=%s:add(secret-value=\"%s\")", storeName,
+                            alias, secret));
+                    assertCredentialValue(storeName, alias, secret);
+                } else {
+                    cli.sendLine(String.format("/subsystem=elytron/credential-store=%s/alias=%s:add()", storeName, alias));
+                    assertCredentialValue(storeName, alias, "");
+                }
             } finally {
-                cli.sendLine(String.format("/subsystem=elytron/credential-store=%s/alias=%s:remove()", storeName, alias));
+                cli.sendLine(String.format("/subsystem=elytron/credential-store=%s/alias=%s:remove()", storeName, alias), true);
             }
         }
     }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/CredentialStoreTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/CredentialStoreTestCase.java
@@ -197,9 +197,9 @@ public class CredentialStoreTestCase extends AbstractCredentialStoreTestCase {
      * Tests creating credential with empty secret.
      */
     @Test
-    @Ignore("WFLY-8143")
     public void testEmptySecret() throws Exception {
         assertAliasAndSecretSupported(CS_NAME_MODIFIABLE, "emptysecret", "");
+        assertAliasAndSecretSupported(CS_NAME_MODIFIABLE, "nullsecret", null);
     }
 
     /**


### PR DESCRIPTION
Testing empty and no value for credential stores.

Jira: https://issues.jboss.org/browse/WFCORE-2455
Core PR: https://github.com/wildfly-security-incubator/wildfly-core/pull/90