### PR TITLE
[WFLY-8426] Fix clean-up in EJBClientDescriptorTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
@@ -39,6 +39,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.ejb.remote.common.EJBManagementUtil;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -89,11 +90,12 @@ public class EJBClientDescriptorTestCase {
 
         @Override
         public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
-            EJBManagementUtil.removeLocalOutboundSocket(managementClient.getControllerClient(), "standard-sockets", outboundSocketName, Authentication.getCallbackHandler());
-            logger.trace("Removed local outbound socket " + outboundSocketName);
-
             EJBManagementUtil.removeRemoteOutboundConnection(managementClient.getControllerClient(), outboundConnectionName, Authentication.getCallbackHandler());
             logger.trace("Removed remote outbound connection " + outboundConnectionName);
+            ServerReload.reloadIfRequired(managementClient.getControllerClient());
+
+            EJBManagementUtil.removeLocalOutboundSocket(managementClient.getControllerClient(), "standard-sockets", outboundSocketName, Authentication.getCallbackHandler());
+            logger.trace("Removed local outbound socket " + outboundSocketName);
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8426
Downstream: https://issues.jboss.org/browse/JBEAP-9815

This commit fixes clean-up in server-setup task method of test `EJBClientDescriptorTestCase`.