### PR TITLE
[WFLY-8497] Extend test coverage for Elytron resources

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
@@ -22,12 +22,18 @@
 
 package org.wildfly.test.integration.elytron.batch;
 
+import static org.jboss.as.controller.client.helpers.ClientConstants.ADDRESS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
+import static org.jboss.as.controller.client.helpers.ClientConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
+
 import java.security.AllPermission;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import javax.batch.operations.JobOperator;
 import javax.batch.operations.JobSecurityException;
 import javax.batch.runtime.BatchRuntime;
@@ -60,13 +66,9 @@ import org.wildfly.security.evidence.PasswordGuessEvidence;
 import org.wildfly.test.security.common.AbstractElytronSetupTask;
 import org.wildfly.test.security.common.elytron.ConfigurableElement;
 import org.wildfly.test.security.common.elytron.EJBApplicationSecurityDomainMapping;
+import org.wildfly.test.security.common.elytron.PermissionRef;
 import org.wildfly.test.security.common.elytron.PropertyFileBasedDomain;
 import org.wildfly.test.security.common.elytron.SimplePermissionMapper;
-
-import static org.jboss.as.controller.client.helpers.ClientConstants.ADDRESS;
-import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
-import static org.jboss.as.controller.client.helpers.ClientConstants.UNDEFINE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
 
 /**
  * This is for testing the BatchPermission from batch-jberet subsystem.
@@ -311,36 +313,36 @@ public class BatchSubsystemSecurityTestCase {
                                     SimplePermissionMapper.PermissionMapping.builder()
                                             .withPrincipals("user1", "anonymous")
                                             .withPermissions(
-                                                    SimplePermissionMapper.Permission.builder()
+                                                    PermissionRef.builder()
                                                             .targetName("*")
                                                             .className(BatchPermission.class.getName())
                                                             .module("org.wildfly.extension.batch.jberet")
                                                             .build(),
-                                                    SimplePermissionMapper.Permission.builder()
+                                                    PermissionRef.builder()
                                                             .className(LoginPermission.class.getName())
                                                             .build())
                                             .build(),
                                     SimplePermissionMapper.PermissionMapping.builder()
                                             .withPrincipals("user2")
                                             .withPermissions(
-                                                    SimplePermissionMapper.Permission.builder()
+                                                    PermissionRef.builder()
                                                             .targetName("stop")
                                                             .className(BatchPermission.class.getName())
                                                             .module("org.wildfly.extension.batch.jberet")
                                                             .build(),
-                                                    SimplePermissionMapper.Permission.builder()
+                                                    PermissionRef.builder()
                                                             .className(LoginPermission.class.getName())
                                                             .build())
                                             .build(),
                                     SimplePermissionMapper.PermissionMapping.builder()
                                             .withPrincipals("user3")
                                             .withPermissions(
-                                                    SimplePermissionMapper.Permission.builder()
+                                                    PermissionRef.builder()
                                                             .targetName("read")
                                                             .className(BatchPermission.class.getName())
                                                             .module("org.wildfly.extension.batch.jberet")
                                                             .build(),
-                                                    SimplePermissionMapper.Permission.builder()
+                                                    PermissionRef.builder()
                                                             .className(LoginPermission.class.getName())
                                                             .build())
                                             .build()

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/permissionmappers/ConstantPermissionMapperTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/permissionmappers/ConstantPermissionMapperTestCase.java
@@ -1,0 +1,328 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.permissionmappers;
+
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.junit.Assert.assertEquals;
+
+import java.io.FilePermission;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.AllPermission;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.PermissionUtils;
+import org.jboss.ejb.client.RemoteEJBPermission;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.joda.time.JodaTimePermission;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.extension.batch.jberet.deployment.BatchPermission;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.permission.ElytronPermission;
+import org.wildfly.security.permission.NoPermission;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.ConstantPermissionMapper;
+import org.wildfly.test.security.common.elytron.PermissionRef;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
+import org.wildfly.test.security.common.elytron.UndertowDomainMapper;
+import org.wildfly.test.security.servlets.CheckIdentityPermissionServlet;
+import org.wildfly.transaction.client.RemoteTransactionPermission;
+
+/**
+ * Test for "constant-permission-mapper" Elytron resource. It tests if the defined permissions are correctly mapped to users.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ ConstantPermissionMapperTestCase.ServerSetup.class })
+public class ConstantPermissionMapperTestCase {
+
+    private static final String SD_DEFAULT = "other";
+    private static final String SD_NO_MAPPER = "no-permission-mapper";
+    private static final String SD_LOGIN = "login-permission";
+    private static final String SD_ALL = "all-permission";
+    private static final String SD_MODULES = "permissions-in-modules";
+    private static final String SD_WRONG_CONFIG = "wrong-config";
+
+    private static final String TARGET_NAME = "name";
+    private static final String TARGET_NAME_START = "start";
+    private static final String ACTION = "action";
+
+    @Deployment(testable = false, name = SD_NO_MAPPER)
+    public static WebArchive deployment1() {
+        return createWar(SD_NO_MAPPER);
+    }
+
+    @Deployment(testable = false, name = SD_DEFAULT)
+    public static WebArchive deployment2() {
+        return createWar(SD_DEFAULT);
+    }
+
+    @Deployment(testable = false, name = SD_LOGIN)
+    public static WebArchive deployment3() {
+        return createWar(SD_LOGIN);
+    }
+
+    @Deployment(testable = false, name = SD_ALL)
+    public static WebArchive deployment4() {
+        return createWar(SD_ALL);
+    }
+
+    @Deployment(testable = false, name = SD_MODULES)
+    public static WebArchive deployment5() {
+        return createWar(SD_MODULES);
+    }
+
+    @Deployment(testable = false, name = SD_WRONG_CONFIG)
+    public static WebArchive deployment6() {
+        return createWar(SD_WRONG_CONFIG);
+    }
+
+    /**
+     * Tests default security domain permissions.
+     */
+    @Test
+    @OperateOnDeployment(SD_DEFAULT)
+    public void testDefaultDomainPermissions(@ArquillianResource URL url) throws Exception {
+        // anonymous
+        assertUserHasntPermission(url, null, null, AllPermission.class.getName(), null, null);
+        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), null, null);
+        assertUserHasPermission(url, null, null, BatchPermission.class.getName(), TARGET_NAME_START, null);
+        assertUserHasPermission(url, null, null, RemoteTransactionPermission.class.getName(), null, null);
+        assertUserHasPermission(url, null, null, RemoteEJBPermission.class.getName(), null, null);
+        // valid user
+        assertUserHasPermission(url, "guest", "guest", LoginPermission.class.getName(), null, null);
+        assertUserHasPermission(url, "guest", "guest", BatchPermission.class.getName(), TARGET_NAME_START, null);
+        assertUserHasPermission(url, "guest", "guest", RemoteTransactionPermission.class.getName(), null, null);
+        assertUserHasPermission(url, "guest", "guest", RemoteEJBPermission.class.getName(), null, null);
+    }
+
+    /**
+     * Tests security domain which doesn't contain any permission-mapper.
+     */
+    @Test
+    @OperateOnDeployment(SD_NO_MAPPER)
+    public void testNoMapper(@ArquillianResource URL url) throws Exception {
+        // anonymous
+        assertUserHasntPermission(url, null, null, AllPermission.class.getName(), null, null);
+        assertUserHasntPermission(url, null, null, LoginPermission.class.getName(), null, null);
+        // valid user
+        assertUserHasntPermission(url, "guest", "guest", LoginPermission.class.getName(), null, null);
+        assertUserHasntPermission(url, "guest", "guest", BatchPermission.class.getName(), TARGET_NAME_START, null);
+    }
+
+    /**
+     * Tests security domain which contains constant-permission-mapper with AllPermission.
+     */
+    @Test
+    @OperateOnDeployment(SD_ALL)
+    public void testAllPermission(@ArquillianResource URL url) throws Exception {
+        // anonymous
+        assertUserHasPermission(url, null, null, AllPermission.class.getName(), null, null);
+        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), null, null);
+        // valid user
+        assertUserHasPermission(url, "guest", "guest", LoginPermission.class.getName(), null, null);
+        assertUserHasPermission(url, "guest", "guest", BatchPermission.class.getName(), TARGET_NAME_START, null);
+        assertUserHasPermission(url, "guest", "guest", NoPermission.class.getName(), null, null);
+    }
+
+    /**
+     * Tests security domain which contains constant-permission-mapper with LoginPermission.
+     */
+    @Test
+    @OperateOnDeployment(SD_LOGIN)
+    public void testLoginPermission(@ArquillianResource URL url) throws Exception {
+        // anonymous
+        assertUserHasntPermission(url, null, null, AllPermission.class.getName(), null, null);
+        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), null, null);
+        // login permission doesn't take into account the name and action
+        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), TARGET_NAME, ACTION);
+
+        // valid user
+        assertUserHasPermission(url, "guest", "guest", LoginPermission.class.getName(), null, null);
+        assertUserHasntPermission(url, "guest", "guest", BatchPermission.class.getName(), TARGET_NAME_START, null);
+        assertUserHasntPermission(url, "guest", "guest", NoPermission.class.getName(), null, null);
+    }
+
+    /**
+     * Tests security domain which contains constant-permission-mapper with permissions from different modules
+     */
+    @Test
+    @OperateOnDeployment(SD_MODULES)
+    public void testPermissionsInModules(@ArquillianResource URL url) throws Exception {
+        // anonymous
+        assertUserHasntPermission(url, null, null, AllPermission.class.getName(), null, null);
+        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), null, null);
+        assertUserHasntPermission(url, null, null, BatchPermission.class.getName(), "stop", null);
+        assertUserHasPermission(url, null, null, BatchPermission.class.getName(), TARGET_NAME_START, null);
+        assertUserHasPermission(url, null, null, JodaTimePermission.class.getName(), TARGET_NAME, null);
+
+        // valid user
+        assertUserHasPermission(url, "guest", "guest", LoginPermission.class.getName(), null, null);
+        assertUserHasPermission(url, "guest", "guest", BatchPermission.class.getName(), TARGET_NAME_START, null);
+        assertUserHasPermission(url, "guest", "guest", JodaTimePermission.class.getName(), TARGET_NAME, null);
+    }
+
+    /**
+     * Tests security domain which contains constant-permission-mapper with permission with non-fitting module name or wrong
+     * classname.
+     */
+    @Test
+    @OperateOnDeployment(SD_WRONG_CONFIG)
+    public void testWrongPermissionModule(@ArquillianResource URL url) throws Exception {
+        assertUserHasntPermission(url, null, null, AllPermission.class.getName(), null, null);
+        assertUserHasntPermission(url, null, null, BatchPermission.class.getName(), TARGET_NAME_START, null);
+        // correct permission has to stay working
+        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), null, null);
+    }
+
+    private void assertUserHasPermission(URL webappUrl, String user, String password, String className, String target,
+            String action) throws Exception {
+        assertEquals("true", doPermissionCheckPostReq(webappUrl, user, password, className, target, action));
+    }
+
+    private void assertUserHasntPermission(URL webappUrl, String user, String password, String className, String target,
+            String action) throws Exception {
+        assertEquals("false", doPermissionCheckPostReq(webappUrl, user, password, className, target, action));
+    }
+
+    /**
+     * Makes request to {@link CheckIdentityPermissionServlet}.
+     */
+    private String doPermissionCheckPostReq(URL url, String user, String password, String className, String target,
+            String action) throws URISyntaxException, UnsupportedEncodingException, IOException, ClientProtocolException {
+        String body;
+        final URI uri = new URI(url.toExternalForm() + CheckIdentityPermissionServlet.SERVLET_PATH.substring(1));
+        final HttpPost post = new HttpPost(uri);
+        List<NameValuePair> nvps = new ArrayList<>();
+        setParam(nvps, CheckIdentityPermissionServlet.PARAM_USER, user);
+        setParam(nvps, CheckIdentityPermissionServlet.PARAM_PASSWORD, password);
+        setParam(nvps, CheckIdentityPermissionServlet.PARAM_CLASS, className);
+        setParam(nvps, CheckIdentityPermissionServlet.PARAM_TARGET, target);
+        setParam(nvps, CheckIdentityPermissionServlet.PARAM_ACTION, action);
+        post.setEntity(new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8));
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            try (final CloseableHttpResponse response = httpClient.execute(post)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == SC_FORBIDDEN && user != null) {
+                    return Boolean.toString(false);
+                }
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                body = EntityUtils.toString(response.getEntity());
+            }
+        }
+        return body;
+    }
+
+    private void setParam(List<NameValuePair> nvps, final String paramName, String paramValue) {
+        if (paramValue != null) {
+            nvps.add(new BasicNameValuePair(paramName, paramValue));
+        }
+    }
+
+    /**
+     * Creates web application with given name security domain name reference. The name is used as the archive name too.
+     */
+    private static WebArchive createWar(final String sd) {
+        return ShrinkWrap.create(WebArchive.class, sd + ".war").addClasses(CheckIdentityPermissionServlet.class)
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(sd), "jboss-web.xml")
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new ElytronPermission("*"),
+                        // FIXME remove this FilePermission once the ELY-1055 is fixed
+                        new FilePermission(System.getProperty("jboss.inst") + "/-", "read") // ELY-1055 workaround
+                ), "permissions.xml")
+                .addAsManifestResource(
+                        Utils.getJBossDeploymentStructure("org.wildfly.extension.batch.jberet",
+                                "org.wildfly.transaction.client", "org.jboss.ejb-client", "org.joda.time"),
+                        "jboss-deployment-structure.xml")
+                .addAsWebInfResource(new StringAsset(SecurityTestConstants.WEB_XML_BASIC_AUTHN), "web.xml");
+    }
+
+    /**
+     * Setup task which configures Elytron security domains for this test.
+     */
+    public static class ServerSetup extends AbstractElytronSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = new ArrayList<>();
+
+            elements.add(
+                    SimpleSecurityDomain.builder()
+                            .withName(SD_NO_MAPPER).withDefaultRealm("ApplicationRealm").withRealms(SecurityDomainRealm
+                                    .builder().withRealm("ApplicationRealm").withRoleDecoder("groups-to-roles").build())
+                            .build());
+            elements.add(UndertowDomainMapper.builder().withName(SD_NO_MAPPER).withApplicationDomains(SD_NO_MAPPER).build());
+
+            addSecurityDomain(elements, SD_ALL, PermissionRef.fromPermission(new AllPermission()));
+            addSecurityDomain(elements, SD_LOGIN, PermissionRef.fromPermission(new LoginPermission(TARGET_NAME, ACTION)));
+            addSecurityDomain(elements, SD_MODULES, PermissionRef.fromPermission(new LoginPermission()),
+                    PermissionRef.fromPermission(new BatchPermission(TARGET_NAME_START), "org.wildfly.extension.batch.jberet"),
+                    PermissionRef.fromPermission(new JodaTimePermission(TARGET_NAME), "org.joda.time"));
+            addSecurityDomain(elements, SD_WRONG_CONFIG,
+                    PermissionRef.fromPermission(new BatchPermission(TARGET_NAME_START), "org.joda.time"),
+                    PermissionRef.builder().className("java.typo.AllPermission").build(),
+                    PermissionRef.fromPermission(new LoginPermission()));
+
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+
+        private void addSecurityDomain(List<ConfigurableElement> elements, String sdName, PermissionRef... permRefs) {
+            elements.add(ConstantPermissionMapper.builder().withName(sdName).withPermissions(permRefs).build());
+            elements.add(
+                    SimpleSecurityDomain.builder().withName(sdName)
+                            .withDefaultRealm("ApplicationFsRealm").withPermissionMapper(sdName).withRealms(SecurityDomainRealm
+                                    .builder().withRealm("ApplicationFsRealm").withRoleDecoder("groups-to-roles").build())
+                            .build());
+            elements.add(UndertowDomainMapper.builder().withName(sdName).withApplicationDomains(sdName).build());
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/principaldecoders/ConstantPrincipalDecoderTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/principaldecoders/ConstantPrincipalDecoderTestCase.java
@@ -1,0 +1,253 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.principaldecoders;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.ConstantPrincipalDecoder;
+import org.wildfly.test.security.common.elytron.ConstantPrincipalTransformer;
+import org.wildfly.test.security.common.elytron.PropertiesRealm;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
+import org.wildfly.test.security.common.elytron.UndertowDomainMapper;
+import org.wildfly.test.security.servlets.SecuredPrincipalPrintingServlet;
+
+/**
+ * Test for "constant-principal-decoder" Elytron resource. It tests if it's correctly used for authentication and remains valid
+ * as authenticated principal. It also checks for handling special characters and chaining with a principal transformer.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ ConstantPrincipalDecoderTestCase.ServerSetup.class })
+public class ConstantPrincipalDecoderTestCase {
+
+    private static final String STR_SYMBOLS = "@!#?$%^&*()%+-{}";
+    private static final String STR_CHINESE = "用戶名";
+    private static final String STR_ARABIC = "اسمالمستخدم";
+    private static final String STR_EURO_LOWER = "žščřžďťňäáéěëíýóůúü";
+    private static final String STR_EURO_UPPER = "ŽŠČŘŽĎŤŇÄÁÉĚËÍÝÓŮÚÜ";
+
+    private static final String NAME = ConstantPrincipalDecoderTestCase.class.getSimpleName();
+    private static final String CONST_ADMIN = "admin";
+    private static final String CONST_WHITESPACE = "two words";
+    private static final String CONST_I18N = STR_SYMBOLS + STR_CHINESE + STR_ARABIC + STR_EURO_LOWER + STR_EURO_UPPER;
+    private static final String PD_NAME_ADMIN = CONST_ADMIN;
+    private static final String PD_NAME_I18N = "i18n";
+    private static final String PD_NAME_WHITESPACE = "whitespace";
+    private static final String SD_NAME_NO_PD = "no-principal-decoder";
+    private static final String SD_NAME_PD_AND_PT = "decoder-and-transformer";
+
+    @Deployment(testable = false, name = PD_NAME_ADMIN)
+    public static WebArchive deployment1() {
+        return createWar(PD_NAME_ADMIN);
+    }
+
+    @Deployment(testable = false, name = PD_NAME_I18N)
+    public static WebArchive deployment2() {
+        return createWar(PD_NAME_I18N);
+    }
+
+    @Deployment(testable = false, name = PD_NAME_WHITESPACE)
+    public static WebArchive deployment3() {
+        return createWar(PD_NAME_WHITESPACE);
+    }
+
+    @Deployment(testable = false, name = SD_NAME_NO_PD)
+    public static WebArchive deployment5() {
+        return createWar(SD_NAME_NO_PD);
+    }
+
+    @Deployment(testable = false, name = SD_NAME_PD_AND_PT)
+    public static WebArchive deployment6() {
+        return createWar(SD_NAME_PD_AND_PT);
+    }
+
+    /**
+     * Tests security domain which doesn't contain any principal-decoder.
+     */
+    @Test
+    @OperateOnDeployment(SD_NAME_NO_PD)
+    public void testNoPrincipalDecoder(@ArquillianResource URL url) throws Exception {
+        assertEquals("Response body is not correct.", CONST_ADMIN,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_ADMIN, SC_OK));
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_WHITESPACE, SC_OK));
+    }
+
+    /**
+     * I18N test for security domain which doesn't contain any principal-decoder.
+     */
+    @Test
+    @OperateOnDeployment(SD_NAME_NO_PD)
+    @Ignore("ELY-1046")
+    public void testNoPrincipalDecoderI18n(@ArquillianResource URL url) throws Exception {
+        assertEquals("Response body is not correct.", CONST_I18N,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_I18N, SC_OK));
+    }
+
+    /**
+     * Tests simple "admin" constant used in the constant-principal-decoder.
+     */
+    @Test
+    @OperateOnDeployment(PD_NAME_ADMIN)
+    public void testAdminPrincipalDecoder(@ArquillianResource URL url) throws Exception {
+        assertEquals("Response body is not correct.", CONST_ADMIN,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_ADMIN, SC_OK));
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_WHITESPACE, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_ADMIN,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_ADMIN, SC_OK));
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_I18N, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_ADMIN,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_ADMIN, SC_OK));
+    }
+
+    /**
+     * Tests constant with a whitespace used in the constant-principal-decoder.
+     */
+    @Test
+    @OperateOnDeployment(PD_NAME_WHITESPACE)
+    public void testWhitespacePrincipalDecoder(@ArquillianResource URL url) throws Exception {
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_ADMIN, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_WHITESPACE, SC_OK));
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_WHITESPACE, SC_OK));
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_I18N, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_WHITESPACE, SC_OK));
+    }
+
+    /**
+     * Tests i18n constant used in the constant-principal-decoder.
+     */
+    @Test
+    @OperateOnDeployment(PD_NAME_I18N)
+    @Ignore("ELY-1046")
+    public void testI18NPrincipalDecoder(@ArquillianResource URL url) throws Exception {
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_ADMIN, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_I18N,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_I18N, SC_OK));
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_WHITESPACE, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_I18N,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_I18N, SC_OK));
+        assertEquals("Response body is not correct.", CONST_I18N,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_I18N, SC_OK));
+    }
+
+    /**
+     * Tests principal-decoder chained with principal-transformer in a security domain.
+     */
+    @Test
+    @OperateOnDeployment(SD_NAME_PD_AND_PT)
+    public void testPrincipalDecoderAndTransformer(@ArquillianResource URL url) throws Exception {
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_ADMIN, CONST_ADMIN, SC_OK));
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_WHITESPACE, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_WHITESPACE, CONST_ADMIN, SC_OK));
+        Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_I18N, SC_UNAUTHORIZED);
+        assertEquals("Response body is not correct.", CONST_WHITESPACE,
+                Utils.makeCallWithBasicAuthn(principalServlet(url), CONST_I18N, CONST_ADMIN, SC_OK));
+    }
+
+    /**
+     * Converts webapp URL to URL containing the included servlet path.
+     */
+    private URL principalServlet(URL url) throws MalformedURLException {
+        return new URL(url.toExternalForm() + SecuredPrincipalPrintingServlet.SERVLET_PATH.substring(1));
+    }
+
+    /**
+     * Creates web application with given name security domain name reference. The name is used as the archive name too.
+     */
+    private static WebArchive createWar(final String sd) {
+        return ShrinkWrap.create(WebArchive.class, sd + ".war").addClasses(SecuredPrincipalPrintingServlet.class)
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(sd), "jboss-web.xml")
+                .addAsWebInfResource(new StringAsset(SecurityTestConstants.WEB_XML_BASIC_AUTHN), "web.xml");
+    }
+
+    /**
+     * Setup task which configures Elytron security domains for this test.
+     */
+    public static class ServerSetup extends AbstractElytronSetupTask {
+        private static final String DEFAULT_PERMISSION_MAPPER = "default-permission-mapper";
+        private static final SecurityDomainRealm SD_REALM_REF = SecurityDomainRealm.builder().withRoleDecoder("groups-to-roles")
+                .withRealm(NAME).build();
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = new ArrayList<>();
+            elements.add(PropertiesRealm.builder().withName(NAME)
+                    .withUser(CONST_ADMIN, CONST_ADMIN, SecuredPrincipalPrintingServlet.ALLOWED_ROLE)
+                    .withUser(CONST_I18N, CONST_I18N, SecuredPrincipalPrintingServlet.ALLOWED_ROLE)
+                    .withUser(CONST_WHITESPACE, CONST_WHITESPACE, SecuredPrincipalPrintingServlet.ALLOWED_ROLE).build());
+            addSecurityDomainWithPermissionMapper(elements, PD_NAME_ADMIN, CONST_ADMIN);
+            addSecurityDomainWithPermissionMapper(elements, PD_NAME_WHITESPACE, CONST_WHITESPACE);
+            addSecurityDomainWithPermissionMapper(elements, PD_NAME_I18N, CONST_I18N);
+            elements.add(SimpleSecurityDomain.builder().withName(SD_NAME_NO_PD).withDefaultRealm(NAME).withRealms(SD_REALM_REF)
+                    .withPermissionMapper(DEFAULT_PERMISSION_MAPPER).build());
+            elements.add(UndertowDomainMapper.builder().withName(SD_NAME_NO_PD).withApplicationDomains(SD_NAME_NO_PD).build());
+
+            elements.add(ConstantPrincipalTransformer.builder().withName(CONST_ADMIN).withConstant(CONST_ADMIN).build());
+            elements.add(SimpleSecurityDomain.builder().withName(SD_NAME_PD_AND_PT).withDefaultRealm(NAME)
+                    .withRealms(SD_REALM_REF).withPrincipalDecoder(PD_NAME_WHITESPACE)
+                    .withPostRealmPrincipalTransformer(CONST_ADMIN).withPermissionMapper(DEFAULT_PERMISSION_MAPPER).build());
+            elements.add(UndertowDomainMapper.builder().withName(SD_NAME_PD_AND_PT).withApplicationDomains(SD_NAME_PD_AND_PT)
+                    .build());
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+
+        private void addSecurityDomainWithPermissionMapper(List<ConfigurableElement> elements, String pdName,
+                String pdConstant) {
+            elements.add(ConstantPrincipalDecoder.builder().withName(pdName).withConstant(pdConstant).build());
+            elements.add(SimpleSecurityDomain.builder().withName(pdName).withPrincipalDecoder(pdName).withDefaultRealm(NAME)
+                    .withRealms(SD_REALM_REF).withPermissionMapper(DEFAULT_PERMISSION_MAPPER).build());
+            elements.add(UndertowDomainMapper.builder().withName(pdName).withApplicationDomains(pdName).build());
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractTraceLoggingServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractTraceLoggingServerSetupTask.java
@@ -72,8 +72,9 @@ public abstract class AbstractTraceLoggingServerSetupTask implements ServerSetup
             op.get("level").set("TRACE");
             updates.add(op);
         }
-        ModelNode op = Util.createEmptyOperation("write-attribute", PATH_LOGGING.append("console-handler", "CONSOLE"));
+        ModelNode op = Util.createEmptyOperation("undefine-attribute", PATH_LOGGING.append("console-handler", "CONSOLE"));
         op.get("name").set("level");
+        updates.add(op);
         CoreUtils.applyUpdates(updates, managementClient.getControllerClient());
     }
 
@@ -100,6 +101,7 @@ public abstract class AbstractTraceLoggingServerSetupTask implements ServerSetup
         ModelNode op = Util.createEmptyOperation("write-attribute", PATH_LOGGING.append("console-handler", "CONSOLE"));
         op.get("name").set("level");
         op.get("value").set("INFO");
+        updates.add(op);
         CoreUtils.applyUpdates(updates, managementClient.getControllerClient());
     }
 

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/AbstractElytronSetupTask.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/AbstractElytronSetupTask.java
@@ -72,7 +72,7 @@ public abstract class AbstractElytronSetupTask
             for (final ConfigurableElement configurableElement : configurableElements) {
                 LOGGER.infov("Adding element {0} ({1})", configurableElement.getName(),
                         configurableElement.getClass().getSimpleName());
-                configurableElement.create(cli);
+                configurableElement.create(modelControllerClient, cli);
             }
         }
         ServerReload.reloadIfRequired(modelControllerClient);
@@ -95,7 +95,7 @@ public abstract class AbstractElytronSetupTask
                 final ConfigurableElement configurableElement = reverseConfigIt.previous();
                 LOGGER.infov("Removing element {0} ({1})", configurableElement.getName(),
                         configurableElement.getClass().getSimpleName());
-                configurableElement.remove(cli);
+                configurableElement.remove(modelControllerClient, cli);
             }
         }
         this.configurableElements = null;

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractConstantHelper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractConstantHelper.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Objects;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Helper abstract parent Elytron constant-* resources with one "constant" attribute.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractConstantHelper extends AbstractConfigurableElement {
+
+    private final String constant;
+
+    protected AbstractConstantHelper(Builder<?> builder) {
+        super(builder);
+        this.constant = Objects.requireNonNull(builder.constant, "Constant has to be provided");
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/%s=%s:add(constant=\"%s\")", getConstantElytronType(), name, constant));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/%s=%s:remove()", getConstantElytronType(), name));
+    }
+
+    /**
+     * Returns elytron node name (e.g. for resource /subsystem=elytron/constant-principal-transformer resources it returns
+     * "constant-principal-transformer").
+     */
+    protected abstract String getConstantElytronType();
+
+    /**
+     * Builder to build {@link AbstractConstantHelper}.
+     */
+    public abstract static class Builder<T extends Builder<T>> extends AbstractConfigurableElement.Builder<T> {
+        private String constant;
+
+        protected Builder() {
+        }
+
+        public T withConstant(String constant) {
+            this.constant = constant;
+            return self();
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractUserRolesCapableElement.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractUserRolesCapableElement.java
@@ -28,21 +28,18 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Abstract parent for {@link UsersRolesSecurityDomain} implementations. It extends {@link AbstractConfigurableElement} and holds
- * user list to be created in domain and provides parent for domain builder objects.
+ * Abstract parent for {@link ConfigurableElement} implementations which are able to configure (and provide) users and roles.
+ * It extends {@link AbstractConfigurableElement} and holds user list to be created.
  *
  * @author Josef Cacek
  */
-public abstract class AbstractUserRolesSecurityDomain extends AbstractConfigurableElement implements UsersRolesSecurityDomain {
+public abstract class AbstractUserRolesCapableElement extends AbstractConfigurableElement implements UsersRolesCapableElement {
 
     private final List<UserWithRoles> usersWithRoles;
 
-    protected final String permissionMapper;
-
-    protected AbstractUserRolesSecurityDomain(Builder<?> builder) {
+    protected AbstractUserRolesCapableElement(Builder<?> builder) {
         super(builder);
         this.usersWithRoles = Collections.unmodifiableList(new ArrayList<>(builder.usersWithRoles));
-        this.permissionMapper = builder.permMapper;
     }
 
     @Override
@@ -51,11 +48,10 @@ public abstract class AbstractUserRolesSecurityDomain extends AbstractConfigurab
     }
 
     /**
-     * Builder to build {@link AbstractUserRolesSecurityDomain}.
+     * Builder to build {@link AbstractUserRolesCapableElement}.
      */
     public abstract static class Builder<T extends Builder<T>> extends AbstractConfigurableElement.Builder<T> {
         private List<UserWithRoles> usersWithRoles = new ArrayList<>();
-        private String permMapper;
 
         protected Builder() {
         }
@@ -81,12 +77,6 @@ public abstract class AbstractUserRolesSecurityDomain extends AbstractConfigurab
             this.usersWithRoles.add(UserWithRoles.builder().withName(username).withPassword(password).withRoles(roles).build());
             return self();
         }
-
-        public final T permissionMapper(String name) {
-            permMapper = name;
-            return self();
-        }
-
     }
 
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConfigurableElement.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConfigurableElement.java
@@ -22,10 +22,12 @@
 
 package org.wildfly.test.security.common.elytron;
 
+import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
 
 /**
- * Interface representing a configurable object in domain model.
+ * Interface representing a configurable object in domain model. The implementation has to override at least one of the
+ * {@code create(...)} methods and one of the {@code remove(...)} methods.
  *
  * @author Josef Cacek
  */
@@ -40,15 +42,30 @@ public interface ConfigurableElement {
      * Creates this element in domain model and also creates other resources if needed (e.g. external files)
      *
      * @param cli connected {@link CLIWrapper} instance
-     * @throws Exception
      */
-    void create(CLIWrapper cli) throws Exception;
+    default void create(CLIWrapper cli) throws Exception {
+        throw new IllegalStateException("The create() method was not properly implemented");
+    }
 
     /**
-     * Reverts the {@link #create(CLIWrapper)} operation.
-     *
-     * @param cli connected {@link CLIWrapper} instance
-     * @throws Exception
+     * Creates this element in domain model and it also may create other resources if needed (e.g. external files).
+     * Implementation can choose if controller client is used or provided CLI wrapper.
      */
-    void remove(CLIWrapper cli) throws Exception;
+    default void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        create(cli);
+    }
+
+    /**
+     * Reverts the changes introdued by {@code create(...)} method(s).
+     */
+    default void remove(CLIWrapper cli) throws Exception {
+        throw new IllegalStateException("The remove() method was not properly implemented");
+    }
+
+    /**
+     * Reverts the changes introdued by {@code create(...)} method(s).
+     */
+    default void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        remove(cli);
+    }
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConstantPermissionMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConstantPermissionMapper.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Configuration for constant-permission-mapper Elytron resource.
+ *
+ * @author Josef Cacek
+ */
+public class ConstantPermissionMapper extends AbstractConfigurableElement implements PermissionMapper {
+
+    private static final String CONSTANT_PERMISSION_MAPPER = "constant-permission-mapper";
+    private static final PathAddress PATH_ELYTRON = PathAddress.pathAddress().append("subsystem", "elytron");
+    private final PermissionRef[] permissions;
+
+    private ConstantPermissionMapper(Builder builder) {
+        super(builder);
+        this.permissions = builder.permissions;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(PATH_ELYTRON.append(CONSTANT_PERMISSION_MAPPER, name));
+        if (permissions != null) {
+            ModelNode permissionsNode = op.get("permissions");
+            for (PermissionRef permissionRef : permissions) {
+                ModelNode permissionRefNode = new ModelNode();
+                permissionRefNode.get("class-name").set(permissionRef.getClassName());
+                setAttribute(permissionRefNode, "module", permissionRef.getModule());
+                setAttribute(permissionRefNode, "target-name", permissionRef.getTargetName());
+                setAttribute(permissionRefNode, "action", permissionRef.getAction());
+                permissionsNode.add(permissionRefNode);
+            }
+        }
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(Util.createRemoveOperation(PATH_ELYTRON.append(CONSTANT_PERMISSION_MAPPER, name)), client);
+    }
+
+    private void setAttribute(ModelNode node, String attribute, String value) {
+        if (value != null) {
+            node.get(attribute).set(value);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for this class.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<ConstantPermissionMapper.Builder> {
+
+        private PermissionRef[] permissions;
+
+        private Builder() {
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        public ConstantPermissionMapper build() {
+            return new ConstantPermissionMapper(this);
+        }
+
+        public Builder withPermissions(PermissionRef... permissions) {
+            this.permissions = permissions;
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConstantPrincipalTransformer.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConstantPrincipalTransformer.java
@@ -19,25 +19,50 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.wildfly.test.security.common.elytron;
 
-import java.util.List;
-
 /**
- * This interface represent Elytron Security Domain with predefined list of users and their roles. It provides ability to tests
- * to come up with own user population for the tested scenario.
- * <p>
- * <b>Implementation notes:</b> If the Elytron security realm can be preconfigured with user list (e.g. domain implementation is
- * creating a property file with users), then the domain created around such a realm should implement this interface.
- * </p>
+ * Elytron constant-principal-transformer configuration implementation.
  *
  * @author Josef Cacek
  */
-public interface UsersRolesSecurityDomain extends SecurityDomain {
+public class ConstantPrincipalTransformer extends AbstractConstantHelper {
+
+    private ConstantPrincipalTransformer(Builder builder) {
+        super(builder);
+    }
+
+
+    @Override
+    protected String getConstantElytronType() {
+        return "constant-principal-transformer";
+    }
 
     /**
-     * Returns predefined (not {@code null}) list of users and their attributes to be created in the domain (realm in fact).
+     * Creates builder.
+     *
+     * @return created builder
      */
-    List<UserWithRoles> getUsersWithRoles();
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder pattern for the class.
+     */
+    public static final class Builder extends AbstractConstantHelper.Builder<Builder> {
+
+        private Builder() {
+        }
+
+        public ConstantPrincipalTransformer build() {
+            return new ConstantPrincipalTransformer(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/FileSystemRealm.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/FileSystemRealm.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.jboss.as.test.integration.security.common.Utils.createTemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Configuration for filesystem-realms Elytron resource.
+ *
+ * @author Josef Cacek
+ */
+public class FileSystemRealm extends AbstractUserRolesCapableElement implements SecurityRealm {
+
+    private final Path path;
+    private final Integer level;
+    private final File tempFolder;
+
+    private FileSystemRealm(Builder builder) {
+        super(builder);
+        if (builder.path != null) {
+            tempFolder = null;
+            this.path = builder.path;
+        } else {
+            try {
+                tempFolder = createTemporaryFolder("ely-" + getName());
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to create temporary folder", e);
+            }
+            this.path = Path.builder().withPath(tempFolder.getAbsolutePath()).build();
+        }
+        level = builder.level;
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        final String levelStr = level == null ? "" : ("level=" + level);
+        cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add(%s, %s)", name, path.asString(), levelStr));
+        for (UserWithRoles user : getUsersWithRoles()) {
+            cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s/identity=%s:add()", name, user.getName()));
+            cli.sendLine(
+                    String.format("/subsystem=elytron/filesystem-realm=%s/identity=%s:set-password(clear={password=\"%s\"})",
+                            name, user.getName(), user.getPassword()));
+            cli.sendLine(
+                    String.format("/subsystem=elytron/filesystem-realm=%s/identity=%s:add-attribute(name=groups, value=[%s])",
+                            name, user.getName(), user.getPassword(), String.join(",", user.getRoles())));
+        }
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:remove()", name));
+        FileUtils.deleteQuietly(tempFolder);
+    }
+
+    /**
+     * Creates builder to build {@link FileSystemRealm}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link FileSystemRealm}.
+     */
+    public static final class Builder extends AbstractUserRolesCapableElement.Builder<Builder> {
+        private Path path;
+        private Integer level;
+
+        private Builder() {
+        }
+
+        public Builder withPath(Path path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder withLevel(Integer level) {
+            this.level = level;
+            return this;
+        }
+
+        public FileSystemRealm build() {
+            return new FileSystemRealm(this);
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PermissionRef.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PermissionRef.java
@@ -1,0 +1,106 @@
+package org.wildfly.test.security.common.elytron;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+public final class PermissionRef {
+    private final String className;
+    private final String module;
+    private final String targetName;
+    private final String action;
+
+    public PermissionRef(Builder builder) {
+        this.className = builder.className;
+        this.module = builder.module;
+        this.targetName = builder.targetName;
+        this.action = builder.action;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public String getTargetName() {
+        return targetName;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static PermissionRef fromPermission(Permission perm) {
+        return fromPermission(perm, null);
+    }
+
+    public static PermissionRef fromPermission(Permission perm, String module) {
+        return builder().className(perm.getClass().getName()).action(perm.getActions()).targetName(perm.getName())
+                .module(module).build();
+    }
+
+    public String toCLIString() {
+        StringBuilder result = new StringBuilder();
+        result.append("{");
+        List<String> arguments = new ArrayList<>();
+        if (action != null) {
+            arguments.add("action=" + action);
+        }
+        if (module != null) {
+            arguments.add("module=" + module);
+        }
+        if (targetName != null) {
+            arguments.add("target-name=" + targetName);
+        }
+        if (className != null) {
+            arguments.add("class-name=" + className);
+        }
+        result.append(StringUtils.join(arguments, ","));
+        result.append("}");
+        return result.toString();
+    }
+
+    public static class Builder {
+        private String className;
+        private String module;
+        private String targetName;
+        private String action;
+
+        public Builder() {
+        }
+
+        public Builder className(String className) {
+            this.className = className;
+            return this;
+        }
+
+        public Builder module(String module) {
+            this.module = module;
+            return this;
+        }
+
+        public Builder targetName(String targetName) {
+            this.targetName = "".equals(targetName) ? null : targetName;
+            return this;
+        }
+
+        public Builder action(String action) {
+            this.action = "".equals(action) ? null : action;
+            return this;
+        }
+
+        public PermissionRef build() {
+            return new PermissionRef(this);
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertiesRealm.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertiesRealm.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.jboss.as.test.integration.security.common.Utils.createTemporaryFolder;
+import static org.jboss.as.test.shared.CliUtils.asAbsolutePath;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.logging.Logger;
+
+/**
+ * Configuration for properties-realms Elytron resource.
+ *
+ * @author Josef Cacek
+ */
+public class PropertiesRealm extends AbstractUserRolesCapableElement implements SecurityRealm {
+
+    private static final Logger LOGGER = Logger.getLogger(PropertiesRealm.class);
+
+    private final String groupsAttribute;
+    private File tempFolder;
+
+    private PropertiesRealm(Builder builder) {
+        super(builder);
+        this.groupsAttribute = builder.groupsAttribute;
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        this.tempFolder = createTemporaryFolder("ely-" + name);
+        final Properties usersProperties = new Properties();
+        final Properties rolesProperties = new Properties();
+        for (UserWithRoles user : getUsersWithRoles()) {
+            usersProperties.setProperty(user.getName(), user.getPassword());
+            rolesProperties.setProperty(user.getName(), String.join(",", user.getRoles()));
+        }
+        File usersFile = writeProperties(usersProperties, "users.properties");
+        File rolesFile = writeProperties(rolesProperties, "roles.properties");
+
+        // /subsystem=elytron/properties-realm=test:add(users-properties={path=/tmp/users.properties, plain-text=true},
+        // groups-properties={path=/tmp/groups.properties}, groups-attribute="groups")
+        final String groupsAttrStr = groupsAttribute == null ? "" : String.format(", groups-attribute=\"%s\"", groupsAttribute);
+        cli.sendLine(String.format(
+                "/subsystem=elytron/properties-realm=%s:add(users-properties={path=\"%s\", plain-text=true}, groups-properties={path=\"%s\"}%s)",
+                name, asAbsolutePath(usersFile), asAbsolutePath(rolesFile), groupsAttrStr));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/properties-realm=%s:remove()", name));
+        FileUtils.deleteQuietly(tempFolder);
+        tempFolder = null;
+    }
+
+    /**
+     * Creates builder to build {@link PropertiesRealm}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private File writeProperties(Properties properties, String fileName) throws IOException {
+        File result = new File(tempFolder, fileName);
+        LOGGER.debugv("Creating property file {0}", result);
+        try (FileOutputStream fos = new FileOutputStream(result)) {
+            // comment $REALM_NAME is just a workaround for https://issues.jboss.org/browse/WFLY-7104
+            properties.store(fos, "$REALM_NAME=" + name + "$");
+        }
+        return result;
+    }
+
+    /**
+     * Builder to build {@link PropertiesRealm}.
+     */
+    public static final class Builder extends AbstractUserRolesCapableElement.Builder<Builder> {
+        private String groupsAttribute;
+
+        private Builder() {
+        }
+
+        public Builder withGroupsAttribute(String groupsAttribute) {
+            this.groupsAttribute = groupsAttribute;
+            return this;
+        }
+
+        public PropertiesRealm build() {
+            return new PropertiesRealm(this);
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertyFileAuthzBasedDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertyFileAuthzBasedDomain.java
@@ -50,7 +50,7 @@ import org.wildfly.security.auth.permission.LoginPermission;
  *
  * @author Ondrej Kotek
  */
-public class PropertyFileAuthzBasedDomain extends AbstractUserRolesSecurityDomain {
+public class PropertyFileAuthzBasedDomain extends AbstractUserRolesCapableElement implements SecurityDomain {
 
     private static final Logger LOGGER = Logger.getLogger(PropertyFileAuthzBasedDomain.class);
 
@@ -132,7 +132,7 @@ public class PropertyFileAuthzBasedDomain extends AbstractUserRolesSecurityDomai
         return new Builder();
     }
 
-    public static final class Builder extends AbstractUserRolesSecurityDomain.Builder<Builder> {
+    public static final class Builder extends AbstractUserRolesCapableElement.Builder<Builder> {
         private String authnRealm;
         private String principalDecoder;
 

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertyFileBasedDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertyFileBasedDomain.java
@@ -48,14 +48,17 @@ import org.wildfly.security.auth.permission.LoginPermission;
  *
  * @author Josef Cacek
  */
-public class PropertyFileBasedDomain extends AbstractUserRolesSecurityDomain {
+public class PropertyFileBasedDomain extends AbstractUserRolesCapableElement implements SecurityDomain {
 
     private static final Logger LOGGER = Logger.getLogger(PropertyFileBasedDomain.class);
 
     private File tempFolder;
 
+    protected final String permissionMapper;
+
     private PropertyFileBasedDomain(Builder builder) {
         super(builder);
+        this.permissionMapper = builder.permMapper;
     }
 
     @Override
@@ -115,13 +118,21 @@ public class PropertyFileBasedDomain extends AbstractUserRolesSecurityDomain {
         return new Builder();
     }
 
-    public static final class Builder extends AbstractUserRolesSecurityDomain.Builder<Builder> {
+    public static final class Builder extends AbstractUserRolesCapableElement.Builder<Builder> {
+
+        private String permMapper;
+
         private Builder() {
             // empty
         }
 
         public PropertyFileBasedDomain build() {
             return new PropertyFileBasedDomain(this);
+        }
+
+        public Builder permissionMapper(String name) {
+            permMapper = name;
+            return self();
         }
 
         @Override

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SecurityRealm.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SecurityRealm.java
@@ -19,50 +19,14 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.test.security.common.elytron;
 
 /**
- * Elytron constant-principal-decoder configuration implementation.
+ * Interface representing Elytron Security realm and resources related to it.
  *
- * @author Ondrej Kotek
+ * @author Josef Cacek
  */
-public class ConstantPrincipalDecoder extends AbstractConstantHelper {
-
-    private ConstantPrincipalDecoder(Builder builder) {
-        super(builder);
-    }
-
-
-    @Override
-    protected String getConstantElytronType() {
-        return "constant-principal-decoder";
-    }
-
-    /**
-     * Creates builder.
-     *
-     * @return created builder
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Builder pattern for the class.
-     */
-    public static final class Builder extends AbstractConstantHelper.Builder<Builder> {
-
-        private Builder() {
-        }
-
-        public ConstantPrincipalDecoder build() {
-            return new ConstantPrincipalDecoder(this);
-        }
-
-        @Override
-        protected Builder self() {
-            return this;
-        }
-    }
+public interface SecurityRealm extends ConfigurableElement {
 
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimplePermissionMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimplePermissionMapper.java
@@ -114,101 +114,9 @@ public class SimplePermissionMapper extends AbstractConfigurableElement implemen
 
     }
 
-    public static final class Permission {
-        private final String className;
-        private final String module;
-        private final String targetName;
-        private final String action;
-
-        public Permission(Builder builder) {
-            this.className = builder.className;
-            this.module = builder.module;
-            this.targetName = builder.targetName;
-            this.action = builder.action;
-        }
-
-        public String getClassName() {
-            return className;
-        }
-
-        public String getModule() {
-            return module;
-        }
-
-        public String getTargetName() {
-            return targetName;
-        }
-
-        public String getAction() {
-            return action;
-        }
-
-        public static Builder builder() {
-            return new Builder();
-        }
-
-
-        public String toCLIString() {
-            StringBuilder result = new StringBuilder();
-            result.append("{");
-            List<String> arguments = new ArrayList<>();
-            if (action != null) {
-                arguments.add("action=" + action);
-            }
-            if (module != null) {
-                arguments.add("module=" + module);
-            }
-            if (targetName != null) {
-                arguments.add("target-name=" + targetName);
-            }
-            if (className != null) {
-                arguments.add("class-name=" + className);
-            }
-            result.append(StringUtils.join(arguments, ","));
-            result.append("}");
-            return result.toString();
-        }
-
-        public static class Builder {
-            private String className;
-            private String module;
-            private String targetName;
-            private String action;
-
-            public Builder() {
-            }
-
-            public Builder className(String className) {
-                this.className = className;
-                return this;
-            }
-
-            public Builder module(String module) {
-                this.module = module;
-                return this;
-            }
-
-            public Builder targetName(String targetName) {
-                this.targetName = targetName;
-                return this;
-            }
-
-            public Builder action(String action) {
-                this.action = action;
-                return this;
-            }
-
-            public Permission build() {
-                // TODO add null checks here
-                return new Permission(this);
-            }
-        }
-
-    }
-
     public static final class PermissionMapping {
 
-        private final List<Permission> permissions;
+        private final List<PermissionRef> permissions;
         private final List<String> principals;
         private final List<String> roles;
 
@@ -218,7 +126,7 @@ public class SimplePermissionMapper extends AbstractConfigurableElement implemen
             this.roles = builder.roles;
         }
 
-        public List<Permission> getPermissions() {
+        public List<PermissionRef> getPermissions() {
             return permissions;
         }
 
@@ -238,7 +146,7 @@ public class SimplePermissionMapper extends AbstractConfigurableElement implemen
             StringBuilder result = new StringBuilder();
             result.append("{permissions=[");
             result.append(permissions.stream()
-                    .map(Permission::toCLIString)
+                    .map(PermissionRef::toCLIString)
                     .collect(Collectors.joining(",")));
             result.append("]");
             if (principals.size() > 0) {
@@ -257,7 +165,7 @@ public class SimplePermissionMapper extends AbstractConfigurableElement implemen
 
         public static final class Builder {
 
-            private List<Permission> permissions;
+            private List<PermissionRef> permissions;
             private List<String> principals;
             private List<String> roles;
 
@@ -267,7 +175,7 @@ public class SimplePermissionMapper extends AbstractConfigurableElement implemen
                 roles = new ArrayList<>();
             }
 
-            public Builder withPermissions(Permission... permissions) {
+            public Builder withPermissions(PermissionRef... permissions) {
                 this.permissions.addAll(Arrays.asList(permissions));
                 return this;
             }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleSecurityDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleSecurityDomain.java
@@ -1,0 +1,278 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron Security domain configuration.
+ *
+ * @author Josef Cacek
+ */
+public class SimpleSecurityDomain extends AbstractConfigurableElement implements SecurityDomain {
+
+    private final String defaultRealm;
+    private final Boolean outflowAnonymous;
+    private final String[] outflowSecurityDomains;
+    private final String permissionMapper;
+    private final String preRealmPrincipalTransformer;
+    private final String postRealmPrincipalTransformer;
+    private final String principalDecoder;
+    private final String realmMapper;
+    private final SecurityDomainRealm[] realms;
+    private final String roleMapper;
+    private final String securityEventListener;
+    private final String[] trustedSecurityDomains;
+
+    private SimpleSecurityDomain(Builder builder) {
+        super(builder);
+        this.defaultRealm = builder.defaultRealm;
+        this.outflowAnonymous = builder.outflowAnonymous;
+        this.outflowSecurityDomains = builder.outflowSecurityDomains;
+        this.permissionMapper = builder.permissionMapper;
+        this.preRealmPrincipalTransformer = builder.preRealmPrincipalTransformer;
+        this.postRealmPrincipalTransformer = builder.postRealmPrincipalTransformer;
+        this.principalDecoder = builder.principalDecoder;
+        this.realmMapper = builder.realmMapper;
+        this.realms = builder.realms;
+        this.roleMapper = builder.roleMapper;
+        this.securityEventListener = builder.securityEventListener;
+        this.trustedSecurityDomains = builder.trustedSecurityDomains;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util
+                .createAddOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("security-domain", name));
+        op.get("default-realm").set(defaultRealm);
+        if (outflowAnonymous != null) {
+            op.get("outflow-anonymous").set(outflowAnonymous);
+        }
+        setAttribute(op, "outflow-security-domains", outflowSecurityDomains);
+        setAttribute(op, "permission-mapper", permissionMapper);
+        setAttribute(op, "post-realm-principal-transformer", postRealmPrincipalTransformer);
+        setAttribute(op, "pre-realm-principal-transformer", preRealmPrincipalTransformer);
+        setAttribute(op, "principal-decoder", principalDecoder);
+        setAttribute(op, "realm-mapper", realmMapper);
+        if (realms != null) {
+            ModelNode realmsNode = op.get("realms");
+            for (SecurityDomainRealm realmRef : realms) {
+                ModelNode realmRefNode = new ModelNode();
+                realmRefNode.get("realm").set(realmRef.realm);
+                setAttribute(realmRefNode, "principal-transformer", realmRef.principalTransformer);
+                setAttribute(realmRefNode, "role-decoder", realmRef.roleDecoder);
+                setAttribute(realmRefNode, "role-mapper", realmRef.roleMapper);
+                realmsNode.add(realmRefNode);
+            }
+        }
+        setAttribute(op, "role-mapper", roleMapper);
+        setAttribute(op, "security-event-listener", securityEventListener);
+        setAttribute(op, "trusted-security-domains", trustedSecurityDomains);
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(Util.createRemoveOperation(
+                PathAddress.pathAddress().append("subsystem", "elytron").append("security-domain", name)), client);
+    }
+
+    private void setAttribute(ModelNode node, String attribute, String value) {
+        if (value != null) {
+            node.get(attribute).set(value);
+        }
+    }
+
+    private void setAttribute(ModelNode node, String attribute, String... listValue) {
+        if (listValue != null) {
+            ModelNode listNode = node.get(attribute);
+            for (String value : listValue) {
+                listNode.add(value);
+            }
+        }
+    }
+
+    /**
+     * Creates builder to build {@link SimpleSecurityDomain}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link SimpleSecurityDomain}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String defaultRealm;
+        private Boolean outflowAnonymous;
+        private String[] outflowSecurityDomains;
+        private String permissionMapper;
+        private String preRealmPrincipalTransformer;
+        private String postRealmPrincipalTransformer;
+        private String principalDecoder;
+        private String realmMapper;
+        private SecurityDomainRealm[] realms;
+        private String roleMapper;
+        private String securityEventListener;
+        private String[] trustedSecurityDomains;
+
+        private Builder() {
+        }
+
+        public Builder withDefaultRealm(String defaultRealm) {
+            this.defaultRealm = defaultRealm;
+            return this;
+        }
+
+        public Builder withOutflowAnonymous(Boolean outflowAnonymous) {
+            this.outflowAnonymous = outflowAnonymous;
+            return this;
+        }
+
+        public Builder withOutflowSecurityDomains(String... outflowSecurityDomains) {
+            this.outflowSecurityDomains = outflowSecurityDomains;
+            return this;
+        }
+
+        public Builder withPermissionMapper(String permissionMapper) {
+            this.permissionMapper = permissionMapper;
+            return this;
+        }
+
+        public Builder withPreRealmPrincipalTransformer(String preRealmPrincipalTransformer) {
+            this.preRealmPrincipalTransformer = preRealmPrincipalTransformer;
+            return this;
+        }
+
+        public Builder withPostRealmPrincipalTransformer(String postRealmPrincipalTransformer) {
+            this.postRealmPrincipalTransformer = postRealmPrincipalTransformer;
+            return this;
+        }
+
+        public Builder withPrincipalDecoder(String principalDecoder) {
+            this.principalDecoder = principalDecoder;
+            return this;
+        }
+
+        public Builder withRealmMapper(String realmMapper) {
+            this.realmMapper = realmMapper;
+            return this;
+        }
+
+        public Builder withRealms(SecurityDomainRealm... realms) {
+            this.realms = realms;
+            return this;
+        }
+
+        public Builder withRoleMapper(String roleMapper) {
+            this.roleMapper = roleMapper;
+            return this;
+        }
+
+        public Builder withSecurityEventListener(String securityEventListener) {
+            this.securityEventListener = securityEventListener;
+            return this;
+        }
+
+        public Builder withTrustedSecurityDomains(String[] trustedSecurityDomains) {
+            this.trustedSecurityDomains = trustedSecurityDomains;
+            return this;
+        }
+
+        public SimpleSecurityDomain build() {
+            return new SimpleSecurityDomain(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
+    public static class SecurityDomainRealm {
+        private final String realm;
+        private final String principalTransformer;
+        private final String roleDecoder;
+        private final String roleMapper;
+
+        private SecurityDomainRealm(Builder builder) {
+            this.realm = builder.realm;
+            this.principalTransformer = builder.principalTransformer;
+            this.roleDecoder = builder.roleDecoder;
+            this.roleMapper = builder.roleMapper;
+        }
+
+        /**
+         * Creates builder to build {@link SecurityDomainRealm}.
+         *
+         * @return created builder
+         */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Builder to build {@link SecurityDomainRealm}.
+         */
+        public static final class Builder {
+            private String realm;
+            private String principalTransformer;
+            private String roleDecoder;
+            private String roleMapper;
+
+            private Builder() {
+            }
+
+            public Builder withRealm(String realm) {
+                this.realm = realm;
+                return this;
+            }
+
+            public Builder withPrincipalTransformer(String principalTransformer) {
+                this.principalTransformer = principalTransformer;
+                return this;
+            }
+
+            public Builder withRoleDecoder(String roleDecoder) {
+                this.roleDecoder = roleDecoder;
+                return this;
+            }
+
+            public Builder withRoleMapper(String roleMapper) {
+                this.roleMapper = roleMapper;
+                return this;
+            }
+
+            public SecurityDomainRealm build() {
+                return new SecurityDomainRealm(this);
+            }
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowDomainMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowDomainMapper.java
@@ -67,7 +67,7 @@ public class UndertowDomainMapper  extends AbstractConfigurableElement implement
                         + "  mechanism-configurations=["
                         + "    {mechanism-name=DIGEST,mechanism-realm-configurations=[{realm-name=%1$s}]},"
                         + "    {mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=%1$s}]},"
-                        + "    {mechanism-name=FORM]}])", name));
+                        + "    {mechanism-name=FORM}])", name));
 
         if (applicationDomains.isEmpty()) {
             // /subsystem=undertow/application-security-domain=test:add(http-authentication-factory=test)

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UsersRolesCapableElement.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UsersRolesCapableElement.java
@@ -19,50 +19,21 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.test.security.common.elytron;
 
+import java.util.List;
+
 /**
- * Elytron constant-principal-decoder configuration implementation.
+ * This interface represent configuration element with predefined list of users and their roles. It provides ability to tests
+ * to come up with own user population for the tested scenario.
  *
- * @author Ondrej Kotek
+ * @author Josef Cacek
  */
-public class ConstantPrincipalDecoder extends AbstractConstantHelper {
-
-    private ConstantPrincipalDecoder(Builder builder) {
-        super(builder);
-    }
-
-
-    @Override
-    protected String getConstantElytronType() {
-        return "constant-principal-decoder";
-    }
+public interface UsersRolesCapableElement extends ConfigurableElement {
 
     /**
-     * Creates builder.
-     *
-     * @return created builder
+     * Returns predefined (not {@code null}) list of users and their attributes to be created.
      */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Builder pattern for the class.
-     */
-    public static final class Builder extends AbstractConstantHelper.Builder<Builder> {
-
-        private Builder() {
-        }
-
-        public ConstantPrincipalDecoder build() {
-            return new ConstantPrincipalDecoder(this);
-        }
-
-        @Override
-        protected Builder self() {
-            return this;
-        }
-    }
-
+    List<UserWithRoles> getUsersWithRoles();
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/servlets/CheckIdentityPermissionServlet.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/servlets/CheckIdentityPermissionServlet.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.servlets;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.Permission;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+
+/**
+ * Servlet which checks if given identity has given permission in current Elytron security domain. If the {@value #PARAM_USER}
+ * request parameter is not provided then an anonymous identity is used, otherwise the identity is retrieved by calling
+ * {@link org.wildfly.security.auth.server.SecurityDomain#authenticate(String, org.wildfly.security.evidence.Evidence)} method
+ * with {@value #PARAM_PASSWORD} request parameter used as the Evidence.
+ * <p>
+ * The checked permission is specified by request parameters {@value #PARAM_CLASS}, {@value #PARAM_TARGET} and
+ * {@value #PARAM_ACTION}.
+ * </p>
+ * <p>
+ * Response body in normal cases contains just "true" or "false" String. If authentication to security domain fails, then status
+ * code {@link HttpServletResponse#SC_FORBIDDEN} is used for the response. If the check permission class parameter is missing
+ * then status code {@link HttpServletResponse#SC_BAD_REQUEST} is used for the response.
+ * </p>
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(CheckIdentityPermissionServlet.SERVLET_PATH)
+public class CheckIdentityPermissionServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/checkIdentityPermission";
+
+    public static final String PARAM_USER = "user";
+    public static final String PARAM_PASSWORD = "password";
+    public static final String PARAM_CLASS = "class";
+    public static final String PARAM_TARGET = "target";
+    public static final String PARAM_ACTION = "action";
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doGet(req, resp);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        resp.setCharacterEncoding("UTF-8");
+
+        SecurityIdentity si = null;
+        final String user = req.getParameter(PARAM_USER);
+
+        if (user != null) {
+            final String password = req.getParameter(PARAM_PASSWORD);
+            try {
+                si = SecurityDomain.getCurrent().authenticate(user, new PasswordGuessEvidence(password.toCharArray()));
+            } catch (Exception e) {
+                e.printStackTrace();
+                resp.sendError(SC_FORBIDDEN, e.getMessage());
+                return;
+            }
+        } else {
+            si = SecurityDomain.getCurrent().getCurrentSecurityIdentity();
+        }
+
+        String className = req.getParameter(PARAM_CLASS);
+        if (className == null) {
+            resp.sendError(SC_BAD_REQUEST, "Parameter class has to be provided");
+            return;
+        }
+        String target = req.getParameter(PARAM_TARGET);
+        String action = req.getParameter(PARAM_ACTION);
+
+        Permission perm = null;
+        try {
+            if (target == null) {
+                perm = (Permission) Class.forName(className).newInstance();
+            } else if (action == null) {
+                perm = (Permission) Class.forName(className).getConstructor(String.class).newInstance(target);
+            } else {
+                perm = (Permission) Class.forName(className).getConstructor(String.class, String.class).newInstance(target,
+                        action);
+            }
+        } catch (Exception e) {
+            throw new ServletException("Unable to create permission instance", e);
+        }
+
+        final PrintWriter writer = resp.getWriter();
+        writer.print(si.implies(perm));
+        writer.close();
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/servlets/SecuredPrincipalPrintingServlet.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/servlets/SecuredPrincipalPrintingServlet.java
@@ -19,40 +19,48 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.security.common.servlets;
+package org.wildfly.test.security.servlets;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.security.Principal;
 
+import javax.annotation.security.DeclareRoles;
 import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * A servlet which reports the name of the callers principal.
+ * A secured servlet that gets request assigned principal ({@link HttpServletRequest#getUserPrincipal()}) and prints its name.
  *
- * @author JanLanik
+ * @author Josef Cacek
  */
-@WebServlet(name = "PrincipalPrintingServlet", urlPatterns = { PrincipalPrintingServlet.SERVLET_PATH })
-public class PrincipalPrintingServlet extends HttpServlet {
+@DeclareRoles({ SecuredPrincipalPrintingServlet.ALLOWED_ROLE })
+@ServletSecurity(@HttpConstraint(rolesAllowed = { SecuredPrincipalPrintingServlet.ALLOWED_ROLE }))
+@WebServlet(SecuredPrincipalPrintingServlet.SERVLET_PATH)
+public class SecuredPrincipalPrintingServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String SERVLET_PATH = "/printPrincipal";
+    public static final String SERVLET_PATH = "/principal";
+    public static final String ALLOWED_ROLE = "JBossAdmin";
 
+    /**
+     * Writes principal name.
+     */
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.setContentType("text/plain");
-        final PrintWriter writer = resp.getWriter();
-        final Principal principal = req.getUserPrincipal();
-        if (null == principal) {
-            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Principal name is printed only for the authenticated users.");
-        } else {
-            writer.write(principal.getName());
+        resp.setCharacterEncoding("UTF-8");
+        Principal userPrincipal = req.getUserPrincipal();
+        if (userPrincipal != null) {
+            final PrintWriter writer = resp.getWriter();
+            writer.print(userPrincipal.getName());
+            writer.close();
         }
-        writer.close();
     }
 }


### PR DESCRIPTION
Upstream JIRA: https://issues.jboss.org/browse/WFLY-8497
EAP JIRA: https://issues.jboss.org/browse/JBEAP-10091

Commit extends test coverage for Elytron resources - `constant-permission-mapper` and `constant-principal-decoder`. It also improves helper configuration classes for Elytron within the testsuite.