### PR TITLE
[WFLY-8567] Enable test previously disabled in Elytron test run.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
@@ -45,8 +45,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -61,11 +59,6 @@ public class SecurityTestCase {
 
     @ContainerResource
     private ManagementClient managementClient;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @Test
     public void testFailedAuthenticationBadUserPass() throws Exception {


### PR DESCRIPTION
Depends on https://github.com/wildfly-security-incubator/wildfly-core/pull/131

Issues: -

https://issues.jboss.org/browse/JBEAP-9117
https://issues.jboss.org/browse/WFLY-8567