### PR TITLE
[WFCORE-2666] Anonymous user don't get LoginPermission in default configuration

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/permissionmappers/ConstantPermissionMapperTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/permissionmappers/ConstantPermissionMapperTestCase.java
@@ -135,7 +135,8 @@ public class ConstantPermissionMapperTestCase {
     public void testDefaultDomainPermissions(@ArquillianResource URL url) throws Exception {
         // anonymous
         assertUserHasntPermission(url, null, null, AllPermission.class.getName(), null, null);
-        assertUserHasPermission(url, null, null, LoginPermission.class.getName(), null, null);
+        // WFCORE-2666
+        assertUserHasntPermission(url, null, null, LoginPermission.class.getName(), null, null);
         assertUserHasPermission(url, null, null, BatchPermission.class.getName(), TARGET_NAME_START, null);
         assertUserHasPermission(url, null, null, RemoteTransactionPermission.class.getName(), null, null);
         assertUserHasPermission(url, null, null, RemoteEJBPermission.class.getName(), null, null);


### PR DESCRIPTION
Small test fix for a permission checking testcase in AS TS. The default elytron configuration in server profiles is changing to not grant the LoginPermission to anonymous user. (Change comes in WildFly Core 3.0.0.Beta16).

https://issues.jboss.org/browse/JBEAP-10309
https://issues.jboss.org/browse/WFCORE-2666