### PR TITLE
[WFLY-8414] Ensure the behaviour of the EJBComponent.getCallerPrincipal() method is consistent for both legacy security and Elytron

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -110,6 +110,8 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
 
+    private final boolean securityRequired;
+
     /**
      * Construct a new instance.
      *
@@ -208,6 +210,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         this.moduleName = componentConfiguration.getModuleName();
         this.distinctName = componentConfiguration.getComponentDescription().getModuleDescription().getDistinctName();
         this.shutDownInterceptorFactory = ejbComponentDescription.getShutDownInterceptorFactory();
+        this.securityRequired = ejbComponentDescription.isSecurityRequired();
     }
 
     @Override
@@ -416,5 +419,9 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     public ShutDownInterceptorFactory getShutDownInterceptorFactory() {
         return shutDownInterceptorFactory;
+    }
+
+    public boolean isSecurityRequired() {
+        return securityRequired;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -123,11 +123,13 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
                             contextID = deploymentUnit.getParent().getName() + "!" + contextID;
                         }
                         EJBComponentDescription ejbComponentDescription = (EJBComponentDescription) description;
+                        final boolean securityRequired = isExplicitSecurityDomainConfigured();
+                        ejbComponentDescription.setSecurityRequired(securityRequired);
                         if (isSecurityDomainKnown()) {
                             final HashMap<Integer, InterceptorFactory> elytronInterceptorFactories = getElytronInterceptorFactories(contextID, ejbComponentDescription.isEnableJacc());
                             elytronInterceptorFactories.forEach((priority, elytronInterceptorFactory) -> configuration.addPostConstructInterceptor(elytronInterceptorFactory, priority));
                         } else {
-                            configuration.addPostConstructInterceptor(new SecurityContextInterceptorFactory(isExplicitSecurityDomainConfigured(), false, contextID), InterceptorOrder.View.SECURITY_CONTEXT);
+                            configuration.addPostConstructInterceptor(new SecurityContextInterceptorFactory(securityRequired, false, contextID), InterceptorOrder.View.SECURITY_CONTEXT);
                         }
                     }
                 });

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -140,6 +140,7 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
         }
 
         final boolean securityRequired = beanHasMethodLevelSecurityMetadata || ejbComponentDescription.hasBeanLevelSecurityMetadata();
+        ejbComponentDescription.setSecurityRequired(securityRequired);
         // setup the security context interceptor
         if (isSecurityDomainKnown) {
             final HashMap<Integer, InterceptorFactory> elytronInterceptorFactories = ejbComponentDescription.getElytronInterceptorFactories(contextID, ejbComponentDescription.isEnableJacc());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/HttpRemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/HttpRemoteIdentityTestCase.java
@@ -106,7 +106,7 @@ public class HttpRemoteIdentityTestCase {
     public void testUnsecured() throws Exception {
         final IntermediateAccess targetBean = lookupEJB(EntryBean.class, IntermediateAccess.class);
 
-        assertEquals("user1", targetBean.getPrincipalName());
+        assertEquals("anonymous", targetBean.getPrincipalName());
     }
 
     private Context getRemoteHTTPContext() throws Exception {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8414
https://issues.jboss.org/browse/JBEAP-9744