### PR TITLE
[WFLY-8676] Unignore RunAsEjbMdbTestCase and RemoteIdentityTestCase for the Elytron profile

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -34,10 +34,8 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -54,11 +52,6 @@ public class RemoteIdentityTestCase {
 
     @ArquillianResource
     private ManagementClient mgmtClient;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     /**
      * Creates a deployment application for this test.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsEjbMdbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsEjbMdbTestCase.java
@@ -39,13 +39,11 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -65,11 +63,6 @@ public class RunAsEjbMdbTestCase {
 
     @ContainerResource
     private InitialContext initialContext;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     static class RunAsTestCaseEJBMDBSetup implements ServerSetupTask {
 


### PR DESCRIPTION
With the fix for WFLY-8414, RunAsEjbMdbTestCase and RemoteIdentityTestCase now pass with the Elytron profile enabled.

https://issues.jboss.org/browse/WFLY-8676
https://issues.jboss.org/browse/JBEAP-10643