### PR TITLE
[WFLY-8676] Re-ignore RemoteIdentityTestCase to prevent issues when ladybird is merged to master

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -34,8 +34,10 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,6 +54,11 @@ public class RemoteIdentityTestCase {
 
     @ArquillianResource
     private ManagementClient mgmtClient;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     /**
      * Creates a deployment application for this test.


### PR DESCRIPTION
In https://github.com/wildfly-security-incubator/wildfly/pull/199, RemoteIdentityTestCase was unignored in the ladybird branch since it passed with the Elytron profile enabled. However, just noticed that Ivo submitted a PR yesterday against master to try to unignore this test but found that although it passes when run individually, it now fails in the full -Delytron CI run (see https://github.com/jbossas/jboss-eap7/pull/1777) and so the test was re-ignored. I'm re-ignoring this test in the ladybird branch to prevent issues when ladybird is merged to master.

https://issues.jboss.org/browse/WFLY-8676
https://issues.jboss.org/browse/JBEAP-10643